### PR TITLE
Avoid duplicate pull request checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -5,6 +5,8 @@
 name: vendor
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 permissions:


### PR DESCRIPTION
Scopes push-triggered test and vendor workflows to main while preserving pull_request and workflow_dispatch. This keeps required PR checks and post-merge coverage, but removes duplicate feature-branch runs.