### PR TITLE
ci: allow archive RPC secret for launch refresh

### DIFF
--- a/.github/workflows/launch-refresh.yml
+++ b/.github/workflows/launch-refresh.yml
@@ -1,4 +1,4 @@
-# launch-refresh: manual-only until a strict full refresh is demonstrated against a no-key public endpoint.
+# launch-refresh: manual-only until a strict full refresh is demonstrated against the configured endpoint.
 # When deliberately dispatched, rebuild the launch index and its numbers file from the most recent full day of
 # launches, rebuild the page that prints their figures and integrity manifest, and open a PR containing the four files. This is the job that
 # writes a branch on its own, so every guardrail is hard and the job commits nothing rather than something
@@ -6,7 +6,8 @@
 # "chain:" below: the vendored code is guarded by verify-vendor instead of a hash of the frozen rule files (there are
 # none here); the page is rebuilt, because its figures and charts are baked in at build time; the membership test
 # allows site/index.html and site/launch-manifest.json as the third and fourth files.
-#   - the collector runs over a day window ending at the latest finalised block, against the public RPC, no key
+#   - the collector runs over a day window ending at the latest finalised block; a repository RPC secret is passed
+#     only through the environment, and an absent secret preserves the collector's checked-in public fallback
 #   - the owned publication guard refuses an empty/partial run, incomplete records, malformed or duplicate factory
 #     events, event hashes that disagree with finalized block headers, and strict ABI metadata/records that do not
 #     rebuild the collector's exact tables and summaries. It reproduces the collector's transaction-sample counters,
@@ -22,10 +23,10 @@
 #   - the only paths that may change are site/launch-index.json, site/launch-numbers.json, site/launch-manifest.json
 #     and site/index.html; any
 #     other modified, deleted or untracked path aborts before the commit
-#   - GITHUB_TOKEN with contents, pull-requests and actions write; no personal token or provider secret; both actions
-#     are pinned by commit SHA. A unique draft PR is opened, then the full test and vendor workflows are explicitly
-#     dispatched and awaited before the PR is marked ready, because pushes made by GITHUB_TOKEN do not recursively
-#     trigger ordinary push workflows
+#   - GITHUB_TOKEN with contents, pull-requests and actions write; no personal token; the optional provider secret is
+#     exposed only to the two RPC-reading steps. Both actions are pinned by commit SHA. A unique draft PR is opened,
+#     then the full test and vendor workflows are explicitly dispatched and awaited before the PR is marked ready,
+#     because pushes made by GITHUB_TOKEN do not recursively trigger ordinary push workflows
 name: launch-refresh
 on:
   workflow_dispatch:
@@ -55,11 +56,15 @@ jobs:
         run: |
           node tools/verify-vendor.mjs
 
-      - name: collect the most recent full day from the public RPC
+      - name: collect the most recent full day from the configured RPC
+        env:
+          LINTCHA_CHAIN_RPC_URL: ${{ secrets.LINTCHA_CHAIN_RPC_URL }}
         run: |
           node tools/launch-collect.mjs --day --out "$RUNNER_TEMP/launch-day.json"
 
       - name: guard the collection with alternate partitions and rebuild its facts from strict chain returns
+        env:
+          LINTCHA_CHAIN_RPC_URL: ${{ secrets.LINTCHA_CHAIN_RPC_URL }}
         run: |
           node tools/collection-guard.mjs --in "$RUNNER_TEMP/launch-day.json" --published site/launch-numbers.json --audit-logs
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ When a refresh lands a new index, the index badge is a line to edit here; nothin
 ## The refresh workflow
 
 `.github/workflows/launch-refresh.yml` is intentionally manual-only until a strict full refresh passes against the
-no-key public endpoint. Its unattended schedule stays removed. A new collection records one exact finalized block number/hash, and the collector and guard use only that
+configured endpoint. Its unattended schedule stays removed. A new collection records one exact finalized block number/hash, and the collector and guard use only that
 numeric state tag for identity reads. The legacy published numbers artifact has no such state and `npm run verify`
 therefore fails closed until a new guarded refresh replaces it; the verifier never invents a state for old bytes.
 When deliberately dispatched, the workflow collects the most recent full day, rebuilds the index, the numbers
@@ -174,9 +174,9 @@ The strict direct-call check re-reads the factory record at the launch block. Be
 guard proves that both the recorded identity state and the historical launch-window state are available. Set a
 credential-bearing archive endpoint in `LINTCHA_CHAIN_RPC_URL`; `--rpc` remains a deliberate override but is visible
 in the process argument list, and neither command prints its URL. An endpoint that cannot read either fixed state is a
-hard failure. That environment path is for a local operator run: the hosted workflow deliberately receives no RPC
-secret and can use only its checked-in public endpoint. Do not weaken the guard or host a key merely to turn that
-infrastructure gap into a green publication.
+hard failure. The hosted workflow passes the repository secret of that name only to its collector and guard steps.
+When the secret is absent, both commands retain their checked-in public fallback and the same strict fixed-state
+checks; an endpoint capability gap therefore remains a hard failure rather than becoming a green publication.
 
 ## The token
 


### PR DESCRIPTION
Adds an optional repository-secret RPC override only to the finalized collector and guard steps. When the secret is absent, the existing fail-closed public RPC fallback is unchanged. Updates the operator note in README.