### PR TITLE
Add guarded Hour-X token activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ social card and the sitemap, is the `origin` key of `site/launch-site.json`.
 - Round F is retained deployer history: the owned `/deployer/` page and `GET/HEAD /api/deployer`. It states the exact
   retained watcher range and exposes bounded launch declarations without token addresses or transactions.
 - Round G is the holder-alert and bot code under `bot/`. It is locally tested. A null token address keeps the feed
-  dormant and does not by itself block deployment; production remains blocked until the room configuration is filled
-  and KV, secrets, routes and cron are confirmed against the live account. Webhook activation additionally waits for
-  the verified non-null token address promised by the public page.
+  dormant and does not by itself block deployment. Room configuration, bindings, secrets, routes, cron and deployment
+  are operational facts outside this tree and are checked with the bot's production checklist. The webhook remains
+  deliberately disconnected while the shared token document carries a null address; it is connected only after the
+  exact non-null token has passed the Hour-X activation and the public deployment has been reproduced.
 - Round H is the public normalization integration kit: `lib/identity.mjs`, the `lintcha-chain` JSON CLI and the
   conformance fixture. Its `read` command refuses a custom index without a matching manifest.
 
@@ -180,9 +181,23 @@ checks; an endpoint capability gap therefore remains a hard failure rather than 
 
 ## The token
 
-`site/token.json` ships with every value null and the page carries no token block, no address and no buy link. When an
-address and a pons link exist, the block renders from that one file; a uniswap link adds its own button. The three
-states are checked by `tests/chain_token_states.mjs` against temporary files, never the tree.
+`site/token.json` is the one activation document for the static page and Worker. Its dormant state has three null
+values and renders no token block, address or buy link; its active state requires one canonical nonzero address and a
+canonical pons HTTPS URL containing that exact address as a separate hex sequence. The optional uniswap field remains
+null unless it is separately configured. Both dormant and active states are checked by `tests/chain_token_states.mjs`.
+
+At Hour X, run the guarded pons-only switch with the two public values:
+
+```
+npm run activate-token -- <CA> <PONS_HTTPS_URL>
+```
+
+Before changing the tree it validates the shared config contract and URL/address binding, proves the configured
+endpoint's chain, reads one canonical finalized header, and uses that header's exact numeric block tag for token code,
+the factory record, `symbol()`, decimals and total supply. The symbol must canonically decode to exactly `LINTCHA`.
+It then reproduces the build and all eight never-line digests in a temporary copy. Only after every proof passes does
+it replace `site/token.json` and the README token line and run the real build. It neither reads the token name nor
+accepts or writes a uniswap URL, secret, Worker setting or git state.
 
 ## Licence
 

--- a/VENDOR.md
+++ b/VENDOR.md
@@ -72,6 +72,7 @@ A path is added here in the same commit that creates the file.
 - `tools/verify-index.mjs`
 - `tools/collection-guard.mjs`
 - `tools/production-smoke.mjs`
+- `tools/activate-token.mjs`
 - `tests/chain_token_states.mjs`
 - `tests/live_wall_test.mjs`
 - `site/icon-32.png`
@@ -100,3 +101,4 @@ A path is added here in the same commit that creates the file.
 - `tests/published_contract_test.mjs`
 - `tests/collection_guard_test.mjs`
 - `tests/production_smoke_test.mjs`
+- `tests/activate_token_test.mjs`

--- a/bot/src/chain.js
+++ b/bot/src/chain.js
@@ -57,6 +57,7 @@ export const TRANSFER_LOGS_OVERFLOW = Object.freeze({ overflow: true });
 export const SEL = {
   balanceOf: selector("balanceOf(address)"),
   decimals: selector("decimals()"),
+  symbol: selector("symbol()"),
   totalSupply: selector("totalSupply()"),
   launched: selector("getLaunchedToken(address)"),
   token0: selector("token0()"),
@@ -99,6 +100,8 @@ const rpcQuantityNumber = value => {
     return Number.isSafeInteger(number) && number >= 0 ? number : null;
   } catch { return null; }
 };
+const rpcStateTag = value => value === "latest" ||
+  (typeof value === "string" && /^0x(?:0|[1-9a-f][0-9a-f]*)$/.test(value)) ? value : null;
 const topicAddress = value => {
   if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(value)) return null;
   const body = value.slice(2).toLowerCase();
@@ -319,12 +322,13 @@ export async function blockNumber(env) {
   } catch { return null; }
 }
 
-async function ethCall(env, to, data) {
+async function ethCall(env, to, data, stateTag = "latest") {
   const address = normal(to);
-  if (!address) return null;
+  const tag = rpcStateTag(stateTag);
+  if (!address || !tag) return null;
   if (!await chainIsOurs(env)) return null;
   try {
-    const r = await call(env, "eth_call", [{ to: address, data }, "latest"]);
+    const r = await call(env, "eth_call", [{ to: address, data }, tag]);
     return typeof r === "string" && r.length > 2 ? r : null;
   } catch { return null; }
 }
@@ -338,27 +342,48 @@ export async function balanceOf(env, token, holder) {
 }
 
 const decimalsCache = new Map();   // a token's decimals never change, so this one may outlive the minute
-export async function decimalsOf(env, token) {
+export async function decimalsOf(env, token, stateTag = "latest") {
   const tokenAddress = normal(token);
-  if (!tokenAddress) return null;
-  if (decimalsCache.has(tokenAddress)) return decimalsCache.get(tokenAddress);
-  const r = await ethCall(env, tokenAddress, SEL.decimals);
+  const tag = rpcStateTag(stateTag);
+  if (!tokenAddress || !tag) return null;
+  const cacheKey = tokenAddress + ":" + tag;
+  if (decimalsCache.has(cacheKey)) return decimalsCache.get(cacheKey);
+  const r = await ethCall(env, tokenAddress, SEL.decimals, tag);
   if (r === null || wordCount(r) !== 1) return null;
   const value = word(r, 0);
   if (value === null) return null;
   const d = Number(value);
   if (!Number.isInteger(d) || d < 0 || d > MAX_TOKEN_DECIMALS) return null;
-  decimalsCache.set(tokenAddress, d);
+  decimalsCache.set(cacheKey, d);
   return d;
 }
 /** Only for tests. */
 export function forgetDecimals() { decimalsCache.clear(); }
 
-export async function totalSupply(env, token) {
+export async function totalSupply(env, token, stateTag = "latest") {
   const tokenAddress = normal(token);
   if (!tokenAddress) return null;
-  const r = await ethCall(env, tokenAddress, SEL.totalSupply);
+  const r = await ethCall(env, tokenAddress, SEL.totalSupply, stateTag);
   return r === null || wordCount(r) !== 1 ? null : word(r, 0);
+}
+
+const canonicalTextReturn = data => {
+  const value = wordBytes(data);
+  if (!value || value.length < 64 || word(data, 0) !== 32n) return null;
+  const length = word(data, 1);
+  if (length === null || length > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+  const size = Number(length), padded = Math.ceil(size / 32) * 32;
+  if (value.length !== 64 + padded || value.slice(64 + size).some(byte => byte !== 0)) return null;
+  try { return new TextDecoder("utf-8", { fatal: true }).decode(value.slice(64, 64 + size)); }
+  catch { return null; }
+};
+
+/** Canonical ABI string returned by symbol(), or null. */
+export async function symbolOf(env, token, stateTag = "latest") {
+  const tokenAddress = normal(token);
+  if (!tokenAddress) return null;
+  const r = await ethCall(env, tokenAddress, SEL.symbol, stateTag);
+  return r === null ? null : canonicalTextReturn(r);
 }
 
 /** A base-unit chain value as whole units for six-significant-figure derived display, or null. */
@@ -374,10 +399,10 @@ export function unitsNumber(value, decimals) {
  * The factory's own record for a token. Fifteen static words, the layout written out in tools/launch/abi.mjs
  * as LAUNCHED_TOKEN. Only the four fields the bot uses are named here.
  */
-export async function launchRecord(env, token) {
+export async function launchRecord(env, token, stateTag = "latest") {
   const requested = normal(token);
   if (!requested) return null;
-  const r = await ethCall(env, FACTORY, SEL.launched + pad(requested));
+  const r = await ethCall(env, FACTORY, SEL.launched + pad(requested), stateTag);
   if (r === null || wordCount(r) !== 15) return null;
   const recordToken = addressWord(r, 0);
   const curve = addressWord(r, 1);

--- a/bot/test/chain_test.mjs
+++ b/bot/test/chain_test.mjs
@@ -6,8 +6,8 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { readToken, forgetToken, forgetDecimals, hasToken, setGate, rpcGate, balanceOf, decimalsOf, totalSupply, unitsNumber, launchRecord, venueOf, transfersAround, priceInPair, SEL, TOPIC_TRANSFER, CHAIN_ID, FACTORY, chainIsOurs, blockNumber, DEFAULT_RPC_IN_FLIGHT, DEFAULT_RPC_SPACING_MS, DEFAULT_RPC_LOGS_SPACING_MS, BOT_RPC_MAX_RETRIES, BOT_RPC_RESPONSE_BODY_LIMIT, MAX_RPC_SPACING_MS, DEFAULT_MAX_TRANSFER_LOGS, MAX_TRANSFER_HEADER_BLOCKS, TRANSFER_LOGS_OVERFLOW, TOKEN_JSON_BODY_LIMIT, TOKEN_JSON_TIMEOUT_MS } from "../src/chain.js";
-import { harness, fakeGate, fakeGateFn, fakeNetwork, wordHex, topicAddr, launchRecordHex, TOKEN_ADDRESS, VENUE_ADDRESS, WALLET_ADDRESS, FIXTURE } from "./fakes.mjs";
+import { readToken, forgetToken, forgetDecimals, hasToken, setGate, rpcGate, balanceOf, decimalsOf, symbolOf, totalSupply, unitsNumber, launchRecord, venueOf, transfersAround, priceInPair, SEL, TOPIC_TRANSFER, CHAIN_ID, FACTORY, chainIsOurs, blockNumber, DEFAULT_RPC_IN_FLIGHT, DEFAULT_RPC_SPACING_MS, DEFAULT_RPC_LOGS_SPACING_MS, BOT_RPC_MAX_RETRIES, BOT_RPC_RESPONSE_BODY_LIMIT, MAX_RPC_SPACING_MS, DEFAULT_MAX_TRANSFER_LOGS, MAX_TRANSFER_HEADER_BLOCKS, TRANSFER_LOGS_OVERFLOW, TOKEN_JSON_BODY_LIMIT, TOKEN_JSON_TIMEOUT_MS } from "../src/chain.js";
+import { harness, fakeGate, fakeGateFn, fakeNetwork, wordHex, stringReturn, topicAddr, launchRecordHex, TOKEN_ADDRESS, VENUE_ADDRESS, WALLET_ADDRESS, FIXTURE } from "./fakes.mjs";
 
 const t = harness("chain");
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -314,6 +314,38 @@ t.ok(await balanceOf({}, zeroAddress, FIXTURE.address) === null && await decimal
   "a zero token address is refused before any chain read");
 t.ok(await balanceOf({}, TOKEN_ADDRESS, zeroAddress) === null && invalidTargetGate.stats.calls === 0,
   "a zero holder is refused before any chain read");
+
+forgetDecimals();
+const defaultTags = [];
+setGate(fakeGateFn(async (method, params) => {
+  if (method === "eth_chainId") return OUR_CHAIN;
+  if (method !== "eth_call") return new Error("unexpected " + method);
+  defaultTags.push(params[1]);
+  const data = params[0].data.slice(0, 10);
+  if (data === SEL.decimals) return wordHex(18);
+  if (data === SEL.symbol) return stringReturn("LINTCHA");
+  if (data === SEL.totalSupply) return wordHex(1000000000n * 10n ** 18n);
+  if (data === SEL.launched) return launchRecordHex({ curve: VENUE_ADDRESS });
+  return new Error("unexpected eth_call");
+}));
+const defaultDecimals = await decimalsOf({}, TOKEN_ADDRESS);
+const defaultSymbol = await symbolOf({}, TOKEN_ADDRESS);
+const defaultSupply = await totalSupply({}, TOKEN_ADDRESS);
+const defaultRecord = await launchRecord({}, TOKEN_ADDRESS);
+t.ok(defaultDecimals === 18 && defaultSymbol === "LINTCHA" && defaultSupply === 1000000000n * 10n ** 18n && defaultRecord?.exists === true &&
+  defaultTags.length === 4 && defaultTags.every(tag => tag === "latest"),
+"the optional-state token and factory helpers retain latest as their exact default tag");
+
+const invalidStateGate = onOurs({});
+forgetDecimals();
+setGate(invalidStateGate);
+t.ok(await decimalsOf({}, TOKEN_ADDRESS, "finalized") === null && await symbolOf({}, TOKEN_ADDRESS, "finalized") === null &&
+  await totalSupply({}, TOKEN_ADDRESS, "finalized") === null && await launchRecord({}, TOKEN_ADDRESS, "finalized") === null && invalidStateGate.stats.calls === 0,
+  "the optional state accepts a canonical numeric tag or the existing latest default, never a moving alias");
+
+setGate(onOurs({ ["eth_call:" + SEL.symbol]: stringReturn("LINTCHA") + "00".repeat(32) }));
+t.ok(await symbolOf({}, TOKEN_ADDRESS) === null, "symbol refuses a decodable string with non-canonical trailing return words");
+
 forgetDecimals();
 setGate(onOurs({
   ["eth_call:" + SEL.balanceOf]: wordHex(7n * 10n ** 18n),

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build": "node tools/build.mjs",
     "verify": "node tools/verify-index.mjs",
     "smoke:production": "node tools/production-smoke.mjs",
-    "test": "node tools/verify-vendor.mjs && node tests/config_contract_test.mjs && node tests/published_contract_test.mjs && node tests/chain_token_states.mjs && node tests/live_wall_test.mjs && node tests/deployer_history_test.mjs && node tests/launch_test.js && node tests/launch_abi_test.mjs && node tests/launch_collector_state_test.mjs && node tests/launch_gate_test.mjs && node tests/collection_guard_test.mjs && node tests/launch_index_test.mjs && node tests/identity_cli_test.mjs && node tests/production_smoke_test.mjs",
+    "test": "node tools/verify-vendor.mjs && node tests/config_contract_test.mjs && node tests/published_contract_test.mjs && node tests/chain_token_states.mjs && node tests/activate_token_test.mjs && node tests/live_wall_test.mjs && node tests/deployer_history_test.mjs && node tests/launch_test.js && node tests/launch_abi_test.mjs && node tests/launch_collector_state_test.mjs && node tests/launch_gate_test.mjs && node tests/collection_guard_test.mjs && node tests/launch_index_test.mjs && node tests/identity_cli_test.mjs && node tests/production_smoke_test.mjs",
+    "activate-token": "node tools/activate-token.mjs",
     "identity": "node tools/identity.mjs",
     "i18n": "node tools/i18n-merge.mjs && node src/tools/i18n_check.js"
   }

--- a/tests/activate_token_test.mjs
+++ b/tests/activate_token_test.mjs
@@ -1,0 +1,219 @@
+// Hour-X activation is exercised only in disposable repository copies against the real chain adapter and a fake
+// Gate. No case reaches the network, the working tree, Cloudflare, Telegram or git.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { activateToken, ActivationFailure, runCli } from "../tools/activate-token.mjs";
+import { CHAIN_ID, SEL, forgetChain, forgetDecimals, setGate } from "../bot/src/chain.js";
+import { fakeGate, launchRecordHex, stringReturn, wordHex } from "../bot/test/fakes.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+let checks = 0, failures = 0;
+const ok = (condition, what) => { checks++; if (!condition) { failures++; console.log("  FAIL " + what); } };
+const ADDRESS_INPUT = "0x" + "Aa".repeat(20);
+const ADDRESS = ADDRESS_INPUT.toLowerCase();
+const CURVE = "0x" + "2".repeat(40);
+const DEPLOYER = "0x" + "3".repeat(40);
+const PAIR = "0x" + "4".repeat(40);
+const PONS = "https://example.invalid/pons/" + ADDRESS + "?token=hour-x&view=buy";
+const RPC = "https://rpc.example.invalid/fixture";
+const COPY_DIRS = ["site", "src", "tools", "lib", "tests"];
+const DORMANT_TOKEN = { address: null, pons: null, uniswap: null };
+const README_PLACEHOLDER = `<!-- the token line, when there is a token: uncomment and paste the contract
+<p align="center"><b>$LINTCHA</b> · <code>0x...</code></p>
+-->`;
+const README_ACTIVE = /<p align="center"><b>\$LINTCHA<\/b> · <code>0x[0-9a-fA-F]{40}<\/code><\/p>/g;
+const WATCHED = [
+  "README.md",
+  "site/token.json",
+  "site/index.html",
+  "site/404.html",
+  "site/sitemap.xml",
+  "site/launch-manifest.json",
+  "src/i18n/en.json",
+  "src/i18n/es.json",
+  "src/i18n/pt.json"
+];
+
+function fixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lintcha-activate-test-"));
+  for (const relative of COPY_DIRS) fs.cpSync(path.join(root, relative), path.join(dir, relative), { recursive: true });
+  const readmeFile = path.join(dir, "README.md");
+  fs.copyFileSync(path.join(root, "README.md"), readmeFile);
+  const readme = fs.readFileSync(readmeFile, "utf8"), active = [...readme.matchAll(README_ACTIVE)];
+  const placeholders = readme.split(README_PLACEHOLDER).length - 1;
+  if (active.length === 1 && placeholders === 0) fs.writeFileSync(readmeFile, readme.replace(README_ACTIVE, README_PLACEHOLDER));
+  else if (active.length !== 0 || placeholders !== 1) throw new Error("fixture could not derive one dormant README token line");
+  fs.writeFileSync(path.join(dir, "site", "token.json"), JSON.stringify(DORMANT_TOKEN, null, 2) + "\n");
+  const built = spawnSync(process.execPath, [path.join(dir, "tools", "build.mjs")], { cwd: dir, encoding: "utf8", windowsHide: true });
+  if (built.error || built.status !== 0) throw new Error("fixture could not build a dormant repository copy");
+  return dir;
+}
+
+function digest(dir) {
+  const hash = crypto.createHash("sha256");
+  for (const relative of WATCHED) {
+    const file = path.join(dir, relative);
+    hash.update(relative).update(fs.existsSync(file) ? fs.readFileSync(file) : "<absent>");
+  }
+  return hash.digest("hex");
+}
+
+function gate(overrides = {}) {
+  const fake = fakeGate({
+    eth_chainId: "0x" + CHAIN_ID.toString(16),
+    eth_getBlockByNumber: { number: "0x1234", hash: "0x" + "5".repeat(64) },
+    eth_getCode: "0x60006000",
+    ["eth_call:" + SEL.launched]: launchRecordHex({ token: ADDRESS, curve: CURVE, deployer: DEPLOYER, pairToken: PAIR }),
+    ["eth_call:" + SEL.symbol]: stringReturn("LINTCHA"),
+    ["eth_call:" + SEL.decimals]: wordHex(18),
+    ["eth_call:" + SEL.totalSupply]: wordHex(1000000n),
+    ...overrides
+  });
+  fake.rawAsked = [];
+  const call = fake.call.bind(fake);
+  fake.call = async (method, params) => {
+    fake.rawAsked.push({ method, params });
+    return call(method, params);
+  };
+  return fake;
+}
+
+async function attemptValues(dir, address = ADDRESS_INPUT, pons = PONS, rpc = gate()) {
+  setGate(rpc);
+  forgetChain();
+  forgetDecimals();
+  try { return await activateToken(address, pons, { root: dir, rpcUrl: RPC }); }
+  finally { setGate(null); forgetChain(); forgetDecimals(); }
+}
+const attempt = (dir, rpc = gate()) => attemptValues(dir, ADDRESS_INPUT, PONS, rpc);
+
+async function rejects(fn) {
+  try { await fn(); return false; }
+  catch (error) { return error instanceof ActivationFailure; }
+}
+
+const made = [];
+try {
+  const live = fixture(); made.push(live);
+  const liveGate = gate();
+  const result = await attempt(live, liveGate);
+  const token = JSON.parse(fs.readFileSync(path.join(live, "site", "token.json"), "utf8"));
+  const readme = fs.readFileSync(path.join(live, "README.md"), "utf8");
+  const index = fs.readFileSync(path.join(live, "site", "index.html"), "utf8");
+  const notFound = fs.readFileSync(path.join(live, "site", "404.html"), "utf8");
+  ok(result.changed === true && result.address === ADDRESS && result.pons === PONS, "a valid proof returns the canonical public activation");
+  ok(JSON.stringify(token) === JSON.stringify({ address: ADDRESS, pons: PONS, uniswap: null }), "only address, pons and the required null uniswap field are written");
+  ok(readme.includes(`<p align="center"><b>$LINTCHA</b> · <code>${ADDRESS}</code></p>`) && !readme.includes("<code>0x...</code>"), "the one README placeholder becomes the exact canonical address");
+  ok(index.split("data-token-address>" + ADDRESS + "<").length - 1 === 3 && notFound.split("data-token-address>" + ADDRESS + "<").length - 1 === 1,
+    "the generated pages carry the exact configured address in their designed address slots");
+  ok((index.match(/hour-x&amp;view=buy/g) || []).length === 2 && (notFound.match(/hour-x&amp;view=buy/g) || []).length === 1, "the generated pages carry the exact escaped primary destination");
+  ok(!/token-btn-uni/.test(index + notFound), "the pons-only command cannot create a secondary venue button");
+  const proofReads = liveGate.rawAsked.filter(call => call.method === "eth_getCode" || call.method === "eth_call");
+  ok(liveGate.rawAsked.filter(call => call.method === "eth_getBlockByNumber").length === 1 &&
+    liveGate.rawAsked.some(call => call.method === "eth_getBlockByNumber" && JSON.stringify(call.params) === JSON.stringify(["finalized", false])) &&
+    liveGate.rawAsked.some(call => call.method === "eth_getCode" && JSON.stringify(call.params) === JSON.stringify([ADDRESS, "0x1234"])) &&
+    proofReads.length === 5 && proofReads.every(call => call.params[1] === "0x1234") &&
+    !liveGate.rawAsked.some(call => JSON.stringify(call.params).includes('"latest"')),
+  "one finalized header supplies the exact numeric tag for every code, token and factory read, with no latest read");
+
+  const firstDigest = digest(live);
+  const again = await attempt(live);
+  ok(again.changed === false && digest(live) === firstDigest, "repeating the exact activation is content-idempotent");
+
+  const fresh = fixture(); made.push(fresh);
+  for (const lang of ["en", "es", "pt"]) fs.rmSync(path.join(fresh, "src", "i18n", lang + ".json"));
+  const freshResult = await attempt(fresh);
+  ok(freshResult.changed === true && ["en", "es", "pt"].every(lang => fs.existsSync(path.join(fresh, "src", "i18n", lang + ".json"))),
+    "activation succeeds in a fresh checkout where ignored merged-language outputs do not exist yet");
+
+  const invalid = fixture(); made.push(invalid);
+  const invalidBefore = digest(invalid);
+  ok(await rejects(() => attemptValues(invalid, ADDRESS_INPUT, "http://example.invalid/buy")) && digest(invalid) === invalidBefore,
+    "a non-HTTPS destination is refused before any tree file changes");
+
+  const unrelatedPons = fixture(); made.push(unrelatedPons);
+  const unrelatedPonsBefore = digest(unrelatedPons);
+  const otherAddress = "0x" + "b".repeat(40);
+  const unrelatedPonsGate = gate();
+  ok(await rejects(() => attemptValues(unrelatedPons, ADDRESS_INPUT, "https://example.invalid/pons/" + otherAddress, unrelatedPonsGate)) &&
+    unrelatedPonsGate.rawAsked.length === 0 && digest(unrelatedPons) === unrelatedPonsBefore,
+    "a pons URL carrying another address is refused before any chain or tree write");
+
+  const wrongChain = fixture(); made.push(wrongChain);
+  const wrongChainBefore = digest(wrongChain);
+  ok(await rejects(() => attempt(wrongChain, gate({ eth_chainId: "0x1" }))) && digest(wrongChain) === wrongChainBefore,
+    "an endpoint on another chain is refused before any tree file changes");
+
+  const noFinalizedHead = fixture(); made.push(noFinalizedHead);
+  const noFinalizedHeadBefore = digest(noFinalizedHead);
+  ok(await rejects(() => attempt(noFinalizedHead, gate({ eth_getBlockByNumber: null }))) && digest(noFinalizedHead) === noFinalizedHeadBefore,
+    "an endpoint without a canonical finalized head is refused before any tree file changes");
+
+  const noFinalizedHash = fixture(); made.push(noFinalizedHash);
+  const noFinalizedHashBefore = digest(noFinalizedHash);
+  ok(await rejects(() => attempt(noFinalizedHash, gate({ eth_getBlockByNumber: { number: "0x1234" } }))) && digest(noFinalizedHash) === noFinalizedHashBefore,
+    "a finalized response without a canonical block hash is refused before any tree file changes");
+
+  const noCode = fixture(); made.push(noCode);
+  const noCodeBefore = digest(noCode);
+  ok(await rejects(() => attempt(noCode, gate({ eth_getCode: "0x" }))) && digest(noCode) === noCodeBefore,
+    "an address without finalized-state code is refused before any tree file changes");
+
+  const noRecord = fixture(); made.push(noRecord);
+  const noRecordBefore = digest(noRecord);
+  ok(await rejects(() => attempt(noRecord, gate({
+    ["eth_call:" + SEL.launched]: launchRecordHex({ token: ADDRESS, curve: CURVE, deployer: DEPLOYER, pairToken: PAIR, exists: false })
+  }))) && digest(noRecord) === noRecordBefore, "a token without the factory's complete live record is refused without a partial activation");
+
+  const wrongSymbol = fixture(); made.push(wrongSymbol);
+  const wrongSymbolBefore = digest(wrongSymbol);
+  ok(await rejects(() => attempt(wrongSymbol, gate({ ["eth_call:" + SEL.symbol]: stringReturn("NOTLINTCHA") }))) && digest(wrongSymbol) === wrongSymbolBefore,
+    "a canonically encoded but different symbol is refused before any tree file changes");
+
+  const noDecimals = fixture(); made.push(noDecimals);
+  const noDecimalsBefore = digest(noDecimals);
+  ok(await rejects(() => attempt(noDecimals, gate({ ["eth_call:" + SEL.decimals]: "0x" }))) && digest(noDecimals) === noDecimalsBefore,
+    "unreadable finalized-state decimals are refused before any tree file changes");
+
+  const noSupply = fixture(); made.push(noSupply);
+  const noSupplyBefore = digest(noSupply);
+  ok(await rejects(() => attempt(noSupply, gate({ ["eth_call:" + SEL.totalSupply]: "0x" }))) && digest(noSupply) === noSupplyBefore,
+    "an unreadable finalized-state total supply is refused before any tree file changes");
+
+  const brokenBuild = fixture(); made.push(brokenBuild);
+  fs.rmSync(path.join(brokenBuild, "src", "templates", "shell.html"));
+  const brokenBefore = digest(brokenBuild);
+  ok(await rejects(() => attempt(brokenBuild)) && digest(brokenBuild) === brokenBefore, "a failed temporary build cannot touch an authored or generated activation file");
+
+  const failedRealBuild = fixture(); made.push(failedRealBuild);
+  for (const lang of ["en", "es", "pt"]) fs.rmSync(path.join(failedRealBuild, "src", "i18n", lang + ".json"));
+  const buildFile = path.join(failedRealBuild, "tools", "build.mjs");
+  fs.writeFileSync(buildFile, `if (!path.basename(process.cwd()).startsWith("lintcha-hour-x-")) {
+  fs.writeFileSync(path.join(process.cwd(), "site", "index.html"), "deliberately broken real build");
+  fs.writeFileSync(path.join(process.cwd(), "src", "i18n", "en.json"), "deliberately created real-build output");
+  process.exit(86);
+}
+` + fs.readFileSync(buildFile, "utf8"));
+  const failedRealBefore = digest(failedRealBuild);
+  ok(await rejects(() => attempt(failedRealBuild)) && digest(failedRealBuild) === failedRealBefore,
+    "a failed real build rolls back both authored files and every build output already touched");
+
+  let usage = "";
+  const status = await runCli([ADDRESS_INPUT], { output: { write() {} }, errorOutput: { write(value) { usage += value; } } });
+  ok(status === 1 && usage === "usage: activate-token <CA> <PONS_HTTPS_URL>\n", "the public CLI accepts exactly two positional values");
+} finally {
+  setGate(null);
+  for (const dir of made) {
+    const resolved = path.resolve(dir);
+    if (path.dirname(resolved) === path.resolve(os.tmpdir()) && path.basename(resolved).startsWith("lintcha-activate-test-")) {
+      fs.rmSync(resolved, { recursive: true, force: true });
+    }
+  }
+}
+
+console.log(`activate token: ${checks} checks, ${failures} failure(s)`);
+process.exit(failures ? 1 : 0);

--- a/tests/chain_acceptance.sh
+++ b/tests/chain_acceptance.sh
@@ -75,12 +75,18 @@ show(\"reproduce block (section 08)\", /id=\"s08\"[\\s\\S]*?data-i18n=\"reproduc
 show(\"independence line (footer)\", /data-i18n=\"footer.independence\"[^>]*>([^<]+)</);
 process.exit(bad ? 1 : 0);'"
 
-run 12 "no project-token activation, rendered token block or buy link in any served HTML: token.json is all null, and every forty-hex address in the tracked or unignored candidate tree has a source-scoped allowance" \
-  "node -e '
-const fs = require(\"fs\"), path = require(\"path\"), { execFileSync } = require(\"child_process\"); let bad = 0;
-const t = JSON.parse(fs.readFileSync(\"site/token.json\", \"utf8\")); console.log(\"site/token.json: \" + JSON.stringify(t)); if (t.address !== null || t.pons !== null || t.uniswap !== null) bad++;
+run 12 "the dormant or active token document agrees exactly with every served page, and every forty-hex address has a source-scoped allowance" \
+  "node --input-type=module -e '
+import fs from \"node:fs\"; import path from \"node:path\"; import { execFileSync } from \"node:child_process\"; import { tokenConfigOf } from \"./lib/config-contract.mjs\"; let bad = 0;
+const rawToken = JSON.parse(fs.readFileSync(\"site/token.json\", \"utf8\")); const t = tokenConfigOf(rawToken); console.log(\"site/token.json: \" + JSON.stringify(rawToken)); if (!t) bad++;
+const active = !!(t && t.address); const exactHits = (text, value) => value ? text.split(value).length - 1 : 0; const htmlUrl = value => String(value).replace(/&/g, \"&amp;\").replace(/</g, \"&lt;\").replace(/>/g, \"&gt;\").replace(/\"/g, \"&quot;\");
 const htmlFiles = []; (function walk(dir) { for (const entry of fs.readdirSync(dir, { withFileTypes: true })) { const file = path.join(dir, entry.name); if (entry.isDirectory()) walk(file); else if (/\\.html$/i.test(entry.name)) htmlFiles.push(file); } })(\"$DIR\");
-for (const file of htmlFiles.sort()) { const page = fs.readFileSync(file, \"utf8\"); const blocks = (page.match(/class\\s*=\\s*(?:\"[^\"]*\\b(?:contract|buy|token-sec|token-btn)\\b[^\"]*\"|\\x27[^\\x27]*\\b(?:contract|buy|token-sec|token-btn)\\b[^\\x27]*\\x27)/gi) || []).length; const buyLinks = (page.match(/\\bhref\\s*=\\s*(?:\"[^\"]*(?:pons|uniswap)[^\"]*\"|\\x27[^\\x27]*(?:pons|uniswap)[^\\x27]*\\x27|[^\\s>]*(?:pons|uniswap)[^\\s>]*)/gi) || []).length; console.log(path.relative(\"$DIR\", file).replace(/\\\\/g, \"/\") + \": token block markup \" + (blocks ? blocks + \" hit(s)\" : \"none\") + \", buy links \" + (buyLinks || \"none\")); if (blocks || buyLinks) bad++; }
+for (const file of htmlFiles.sort()) { const rel = path.relative(\"$DIR\", file).replace(/\\\\/g, \"/\"), page = fs.readFileSync(file, \"utf8\"); const blocks = (page.match(/class\\s*=\\s*(?:\"[^\"]*\\b(?:contract|buy|token-sec|token-btn)\\b[^\"]*\"|\\x27[^\\x27]*\\b(?:contract|buy|token-sec|token-btn)\\b[^\\x27]*\\x27)/gi) || []).length; const addressHits = active ? exactHits(page, \"data-token-address>\" + t.address + \"<\") : 0, ponsHits = active ? exactHits(page, htmlUrl(t.pons)) : 0, uniswapHits = active && t.uniswap ? exactHits(page, htmlUrl(t.uniswap)) : 0; let agrees;
+  if (!active) agrees = blocks === 0;
+  else if (rel === \"index.html\") agrees = addressHits === 3 && ponsHits === 2 && uniswapHits === (t.uniswap ? 1 : 0) && blocks >= 4;
+  else if (rel === \"404.html\") agrees = addressHits === 1 && ponsHits === 1 && uniswapHits === 0 && blocks >= 2;
+  else agrees = addressHits === 0 && ponsHits === 0 && uniswapHits === 0 && blocks === 0;
+  console.log(rel + \": token state \" + (active ? \"active\" : \"dormant\") + \", address slots \" + addressHits + \", primary link \" + ponsHits + \", markup \" + blocks + (agrees ? \"\" : \" <- MISMATCH\")); if (!agrees) bad++; }
 const files = execFileSync(\"git\", [\"ls-files\", \"--cached\", \"--others\", \"--exclude-standard\", \"-z\"], { encoding: \"utf8\" }).split(\"\\0\").filter(Boolean);
 const syntheticAddress = /^(?:0x([0-9a-f])\\1{39}|0x1[0]{38}[1-4]|0x(?:(?:10){20}|(?:20){20})|0x0{39}1)$/i;
 const ALLOW = [
@@ -96,7 +102,8 @@ const ALLOW = [
   [/^tests[\\/\\\\](?:chain_acceptance\\.sh|launch_abi_test\\.mjs|launch_extraction\\.mjs)$/, /0xca11bde05977b3631167028862be2a173976ca11/i, \"the Multicall3 constant under test\"],
   [/^tests[\\/\\\\]chain_acceptance\\.sh$/, /0xe33e9e479df8802cb0866d5d05258bec4cf62948/i, \"the wrapped native constant in the guard allowance\"]
 ];
-let hits = 0; for (const f of files) { if (/\\.(png|woff2|jpg|log)$/i.test(f)) continue;   /* *.log is gitignored: a run record, not the tree */ const s = fs.readFileSync(f, \"utf8\"); for (const m of s.matchAll(/(?<![0-9a-fA-F])0x[0-9a-fA-F]{40}(?![0-9a-fA-F])/gi)) { hits++; const rel = f.replace(/^\\.[\\/\\\\]/, \"\"); const a = ALLOW.find(([fr, ar]) => fr.test(rel) && ar.test(m[0])); console.log(\"  \" + rel + \": \" + m[0].slice(0, 10) + \"… \" + (a ? \"allowed, \" + a[2] : \"NOT ALLOWED\")); if (!a) bad++; } }
+const activeAddressFiles = new Set([\"site/token.json\", \"site/index.html\", \"site/404.html\", \"README.md\"]);
+let hits = 0; for (const f of files) { if (/\\.(png|woff2|jpg|log)$/i.test(f)) continue;   /* *.log is gitignored: a run record, not the tree */ const s = fs.readFileSync(f, \"utf8\"); for (const m of s.matchAll(/(?<![0-9a-fA-F])0x[0-9a-fA-F]{40}(?![0-9a-fA-F])/gi)) { hits++; const rel = f.replace(/^\\.[\\/\\\\]/, \"\"); const projectToken = active && activeAddressFiles.has(rel) && m[0].toLowerCase() === t.address; const a = projectToken ? [null, null, \"the exact active address from site/token.json\"] : ALLOW.find(([fr, ar]) => fr.test(rel) && ar.test(m[0])); console.log(\"  \" + rel + \": \" + m[0].slice(0, 10) + \"… \" + (a ? \"allowed, \" + a[2] : \"NOT ALLOWED\")); if (!a) bad++; } }
 console.log(\"forty-hex strings in the tree: \" + hits + \", not allowed: \" + bad); process.exit(bad ? 1 : 0);'"
 
 run 13 "i18n_check passes on all three languages (after the merge), only en is emitted" \

--- a/tests/chain_token_states.mjs
+++ b/tests/chain_token_states.mjs
@@ -1,6 +1,6 @@
 // lintcha-chain, the token block's three states and the header cluster's links, built and checked without touching the
-// tree. site/token.json ships with every value null and stays that way until the token is really deployed; site/links.json
-// names only accounts that really exist (no placeholder, no zeroes, no buy link, no empty slot in the tree); this test
+// tree. site/token.json may carry either the explicit all-null dormant state or one exact active state; site/links.json
+// names only accounts that really exist (no placeholder, no zeroes, no empty slot in the tree); this test
 // writes a temporary token.json with an address made up at run time, builds into a temporary directory with --token and
 // --out, and checks what each state renders:
 //   a. all null           no contract row, no buy button, no token section, no launch band, the cluster is GITHUB, X
@@ -24,8 +24,8 @@
 // section as three cards and one wide, the sprite in its three places, and the roadmap line against the three
 // phase lists it was folded out of.
 //
-// Then it checks the tree's own site/token.json is all null, site/links.json carries only the confirmed Telegram
-// account, and the tree's site/index.html carries exactly that account and no token state.
+// Then it checks that the tree's own site/token.json and rendered page agree exactly in either dormant or active state,
+// and that site/links.json carries only the confirmed Telegram account alongside the default X account.
 //   node tests/chain_token_states.mjs
 import fs from "node:fs";
 import os from "node:os";
@@ -33,11 +33,14 @@ import path from "node:path";
 import crypto from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { tokenConfigOf } from "../lib/config-contract.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 let checks = 0, failures = 0;
 const ok = (cond, what) => { checks++; if (!cond) { failures++; console.log("  FAIL " + what); } };
 const count = (html, re) => (html.match(re) || []).length;
+const re = value => String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const attr = value => String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 // the hrefs of the cluster's outbound items, in the order the build renders them
 const outHrefs = html => (html.match(/class="out" href="[^"]*"/g) || []).map(m => m.slice('class="out" href="'.length, -1));
 // the cluster's own markup: outbound anchors only, no nested div, so the first closing tag ends it
@@ -177,11 +180,27 @@ ok(!l.includes(X_DEFAULT), "the default X account is not on the page once links.
 
 console.log("the tree");
 const treeToken = JSON.parse(fs.readFileSync(path.join(root, "site", "token.json"), "utf8"));
-ok(treeToken.address === null && treeToken.pons === null && treeToken.uniswap === null, "site/token.json is all null");
+const treeState = tokenConfigOf(treeToken);
+ok(!!treeState, "site/token.json matches the shared dormant-or-active contract");
 const treeLinks = JSON.parse(fs.readFileSync(path.join(root, "site", "links.json"), "utf8"));
 ok(treeLinks.x === null && treeLinks.telegram === TELEGRAM_DEFAULT, "site/links.json leaves X on its default and names the confirmed Telegram room");
 const tree = fs.readFileSync(path.join(root, "site", "index.html"), "utf8");
-ok(count(tree, /class="contract"|class="buy"|token-sec|class="band"/g) === 0, "site/index.html carries no token block and no band");
+if (treeState && treeState.address === null) {
+  ok(treeState.pons === null && treeState.uniswap === null, "the dormant tree has no detached buy destination");
+  ok(count(tree, /class="contract"|class="buy"|token-sec|class="band"/g) === 0, "the dormant page carries no token block and no band");
+  ok(count(tree, /data-token-address|data-copy-address/g) === 0, "the dormant page carries no address or copy slot");
+} else if (treeState) {
+  const a = re(treeState.address), p = re(attr(treeState.pons));
+  ok(count(tree, /class="contract"/g) === 1 && count(tree, /class="buy"/g) === 1 && count(tree, /class="sec token-sec"/g) === 1 && count(tree, /class="band"/g) === 1,
+    "the active page carries one contract row, primary buy, token section and band");
+  ok(count(tree, new RegExp(`data-token-address>${a}<`, "g")) === 3 && count(tree, /data-copy-address/g) === 2,
+    "the active page carries only its exact configured address in all three slots and two copy buttons");
+  ok(count(tree, new RegExp(`class="buy" href="${p}"`, "g")) === 1 && count(tree, new RegExp(`class="token-btn token-btn-pons" href="${p}"`, "g")) === 1,
+    "the active page carries the exact configured pons URL in both primary destinations");
+  if (treeState.uniswap === null) ok(count(tree, /token-btn-uni/g) === 0, "a null uniswap destination renders no secondary button");
+  else ok(count(tree, new RegExp(`class="token-btn token-btn-uni" href="${re(attr(treeState.uniswap))}"`, "g")) === 1,
+    "a configured uniswap destination renders exactly once");
+}
 ok(!tree.includes(address), "the made-up address is not in the tree's page");
 ok(!tree.includes(xAccount) && !tree.includes(telegram), "the made-up accounts are not in the tree's page");
 ok(count(tree, /class="out"/g) === 3 && outHrefs(tree)[1] === X_DEFAULT && outHrefs(tree)[2] === TELEGRAM_DEFAULT && count(tree, /data-i18n="nav\.telegram"/g) === 1, "the tree's page links the default X account and the confirmed Telegram room");

--- a/tools/activate-token.mjs
+++ b/tools/activate-token.mjs
@@ -1,0 +1,296 @@
+// One guarded Hour-X switch. The command accepts only the public contract address and its primary pons HTTPS URL:
+//
+//   node tools/activate-token.mjs <CA> <PONS_HTTPS_URL>
+//
+// The bot deliberately has no second token-address setting. This command proves the address against the configured
+// chain, builds and checks a complete temporary repository copy, and only then replaces the authored activation
+// document and README line together. The real build is the final step; any failure restores every touched tree file.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { tokenConfigBytesOf, tokenConfigOf } from "../lib/config-contract.mjs";
+import {
+  DEFAULT_RPC,
+  chainIsOurs,
+  decimalsOf,
+  forgetChain,
+  forgetDecimals,
+  launchRecord,
+  rpcGate,
+  symbolOf,
+  totalSupply
+} from "../bot/src/chain.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, "..");
+const TOKEN_REL = path.join("site", "token.json");
+const README_REL = "README.md";
+const BUILD_OUTPUTS = [
+  path.join("site", "index.html"),
+  path.join("site", "404.html"),
+  path.join("site", "sitemap.xml"),
+  path.join("site", "launch-manifest.json"),
+  path.join("src", "i18n", "en.json"),
+  path.join("src", "i18n", "es.json"),
+  path.join("src", "i18n", "pt.json")
+];
+const PREFLIGHT_DIRS = ["site", "src", "tools", "lib", "tests"];
+const TOKEN_LINE = address => `<p align="center"><b>$LINTCHA</b> · <code>${address}</code></p>`;
+const PLACEHOLDER = /<!-- the token line, when there is a token: uncomment and paste the contract\r?\n<p align="center"><b>\$LINTCHA<\/b> · <code>0x\.\.\.<\/code><\/p>\r?\n-->/g;
+const ACTIVE_LINE = /<p align="center"><b>\$LINTCHA<\/b> · <code>(0x[0-9a-fA-F]{40})<\/code><\/p>/g;
+
+export class ActivationFailure extends Error {
+  constructor(message) { super(message); this.name = "ActivationFailure"; }
+}
+const fail = message => { throw new ActivationFailure(message); };
+const bytes = file => fs.readFileSync(file);
+const sameBytes = (a, b) => Buffer.compare(a, b) === 0;
+const snapshotOf = file => fs.existsSync(file) ? { existed: true, value: bytes(file) } : { existed: false, value: null };
+const differs = (file, before) => before.existed !== fs.existsSync(file) ||
+  (before.existed && !sameBytes(before.value, bytes(file)));
+const escapePattern = value => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const escapeAttribute = value => String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+const count = (text, pattern) => (text.match(pattern) || []).length;
+
+function readActivation(root) {
+  const file = path.join(root, TOKEN_REL);
+  const raw = bytes(file);
+  const value = tokenConfigBytesOf(raw);
+  if (!value) fail("the current token.json does not match the shared activation contract");
+  return { file, raw, value };
+}
+
+function nextReadme(raw, address) {
+  const text = raw.toString("utf8");
+  const placeholders = [...text.matchAll(PLACEHOLDER)];
+  const active = [...text.matchAll(ACTIVE_LINE)];
+  if (placeholders.length === 1 && active.length === 0) {
+    return Buffer.from(text.replace(PLACEHOLDER, TOKEN_LINE(address)), "utf8");
+  }
+  if (placeholders.length === 0 && active.length === 1 && active[0][1] === address) return raw;
+  fail("the README token line is missing, duplicated or names another address");
+}
+
+function activationInput(address, pons) {
+  const config = tokenConfigOf({ address, pons, uniswap: null });
+  if (!config || !config.address || !config.pons || config.uniswap !== null) {
+    fail("expected one nonzero contract address and one canonical HTTPS pons URL");
+  }
+  const boundAddress = new RegExp(`(?<![0-9a-f])${escapePattern(config.address)}(?![0-9a-f])`, "i");
+  if (!boundAddress.test(config.pons)) fail("the canonical pons URL does not contain the exact contract address");
+  return config;
+}
+
+function runNode(entry, args, cwd) {
+  const result = spawnSync(process.execPath, [entry, ...args], {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+    windowsHide: true
+  });
+  if (result.error || result.status !== 0) fail("a temporary build or its activation contract failed");
+  return result.stdout || "";
+}
+
+async function proveFinalizedState(config, rpcUrl) {
+  const env = { RPC_URL: rpcUrl || DEFAULT_RPC };
+  forgetChain();
+  forgetDecimals();
+  if (!await chainIsOurs(env)) fail("the configured endpoint did not prove the expected chain");
+  const gate = rpcGate(env);
+  if (!gate) fail("the configured endpoint is not a canonical HTTPS URL");
+  let finalized;
+  try { finalized = await gate.call("eth_getBlockByNumber", ["finalized", false]); }
+  catch { fail("the configured endpoint did not return a canonical finalized head"); }
+  if (!finalized || typeof finalized !== "object" || Array.isArray(finalized) ||
+      typeof finalized.number !== "string" || !/^0x(?:0|[1-9a-f][0-9a-f]*)$/.test(finalized.number) ||
+      typeof finalized.hash !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(finalized.hash) || /^0x0{64}$/i.test(finalized.hash)) {
+    fail("the configured endpoint did not return a canonical finalized head");
+  }
+  const stateTag = finalized.number;
+
+  let code;
+  try { code = await gate.call("eth_getCode", [config.address, stateTag]); }
+  catch { fail("the configured endpoint could not read token code at the finalized state"); }
+  if (typeof code !== "string" || !/^0x(?:[0-9a-fA-F]{2})+$/.test(code) || /^0x(?:00)+$/i.test(code)) {
+    fail("the address has no nonzero contract code at the finalized state");
+  }
+
+  const record = await launchRecord(env, config.address, stateTag);
+  if (!record || record.exists !== true) fail("the factory does not return a complete record for this token at the finalized state");
+  const symbol = await symbolOf(env, config.address, stateTag);
+  if (symbol !== "LINTCHA") fail("the token symbol at the finalized state is not exactly LINTCHA");
+  const decimals = await decimalsOf(env, config.address, stateTag);
+  if (decimals === null) fail("the token decimals are unreadable at the finalized state");
+  const supply = await totalSupply(env, config.address, stateTag);
+  if (supply === null) fail("the token total supply is unreadable at the finalized state");
+  return { stateTag, record, symbol, decimals, supply };
+}
+
+function verifyRendered(root, config, readmeBytes) {
+  const token = tokenConfigBytesOf(bytes(path.join(root, TOKEN_REL)));
+  if (!token || JSON.stringify(token) !== JSON.stringify(config)) fail("the built token document does not equal the requested activation");
+
+  const index = fs.readFileSync(path.join(root, "site", "index.html"), "utf8");
+  const notFound = fs.readFileSync(path.join(root, "site", "404.html"), "utf8");
+  const address = escapePattern(config.address);
+  const href = escapePattern(escapeAttribute(config.pons));
+  if (count(index, new RegExp(`data-token-address>${address}<`, "g")) !== 3 ||
+      count(index, /data-copy-address/g) !== 2 ||
+      count(index, new RegExp(`class="buy" href="${href}"`, "g")) !== 1 ||
+      count(index, new RegExp(`class="token-btn token-btn-pons" href="${href}"`, "g")) !== 1 ||
+      /token-btn-uni/.test(index)) {
+    fail("the front page did not render the exact pons-only activation state");
+  }
+  if (count(notFound, new RegExp(`data-token-address>${address}<`, "g")) !== 1 ||
+      count(notFound, /data-copy-address/g) !== 1 ||
+      count(notFound, new RegExp(`class="buy" href="${href}"`, "g")) !== 1 ||
+      /token-btn-uni/.test(notFound)) {
+    fail("the not-found page did not render the exact activation header");
+  }
+
+  const readme = readmeBytes.toString("utf8");
+  const active = [...readme.matchAll(ACTIVE_LINE)];
+  if (active.length !== 1 || active[0][1] !== config.address || [...readme.matchAll(PLACEHOLDER)].length !== 0) {
+    fail("the README does not carry exactly the requested public contract line");
+  }
+}
+
+function copyPreflightTree(root, destination) {
+  for (const relative of PREFLIGHT_DIRS) {
+    const source = path.join(root, relative);
+    if (!fs.existsSync(source)) fail("the repository is missing a preflight directory");
+    fs.cpSync(source, path.join(destination, relative), { recursive: true, force: false });
+  }
+}
+
+function tempPreflight(root, config, readmeBytes) {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "lintcha-hour-x-"));
+  try {
+    copyPreflightTree(root, temp);
+    fs.writeFileSync(path.join(temp, README_REL), readmeBytes);
+    fs.writeFileSync(path.join(temp, TOKEN_REL), JSON.stringify(config, null, 2) + "\n");
+    runNode(path.join(temp, "tools", "build.mjs"), [], temp);
+    verifyRendered(temp, config, readmeBytes);
+    // This state-aware test also pins all eight never lines in all three source languages by digest.
+    runNode(path.join(temp, "tests", "chain_token_states.mjs"), [], temp);
+    return new Map(BUILD_OUTPUTS.map(relative => [relative, bytes(path.join(temp, relative))]));
+  } finally {
+    const resolved = path.resolve(temp);
+    if (path.dirname(resolved) === path.resolve(os.tmpdir()) && path.basename(resolved).startsWith("lintcha-hour-x-")) {
+      fs.rmSync(resolved, { recursive: true, force: true });
+    }
+  }
+}
+
+function atomicReplace(file, value) {
+  const id = crypto.randomBytes(8).toString("hex");
+  const pending = file + ".activate-" + id + ".tmp";
+  const backup = file + ".activate-" + id + ".bak";
+  fs.writeFileSync(pending, value, { flag: "wx" });
+  let moved = false;
+  try {
+    fs.renameSync(file, backup);
+    moved = true;
+    fs.renameSync(pending, file);
+    fs.rmSync(backup, { force: true });
+  } catch (error) {
+    try { if (fs.existsSync(pending)) fs.rmSync(pending, { force: true }); } catch {}
+    try {
+      if (moved && fs.existsSync(backup)) {
+        if (fs.existsSync(file)) fs.rmSync(file, { force: true });
+        fs.renameSync(backup, file);
+      }
+    } catch {}
+    throw error;
+  }
+}
+
+function atomicCreate(file, value) {
+  const pending = file + ".activate-" + crypto.randomBytes(8).toString("hex") + ".tmp";
+  fs.writeFileSync(pending, value, { flag: "wx" });
+  try { fs.renameSync(pending, file); }
+  catch (error) {
+    try { if (fs.existsSync(pending)) fs.rmSync(pending, { force: true }); } catch {}
+    throw error;
+  }
+}
+
+function restore(snapshot) {
+  const failed = [];
+  for (const [file, before] of snapshot) {
+    try {
+      if (!before.existed) {
+        if (fs.existsSync(file)) fs.rmSync(file, { force: true });
+      } else if (fs.existsSync(file)) atomicReplace(file, before.value);
+      else atomicCreate(file, before.value);
+    } catch { failed.push(file); }
+  }
+  if (failed.length) fail("activation failed and its local rollback could not restore every touched file");
+}
+
+export async function activateToken(address, pons, options = {}) {
+  const root = path.resolve(options.root || ROOT);
+  const config = activationInput(address, pons);
+  const current = readActivation(root);
+  if (current.value.address !== null && JSON.stringify(current.value) !== JSON.stringify(config)) {
+    fail("token.json already carries another activation");
+  }
+  const readmeFile = path.join(root, README_REL);
+  const readmeRaw = bytes(readmeFile);
+  const readmeNext = nextReadme(readmeRaw, config.address);
+
+  // Network and build proof complete before the first write to the repository tree.
+  await proveFinalizedState(config, options.rpcUrl || process.env.LINTCHA_CHAIN_RPC_URL || DEFAULT_RPC);
+  const proposed = tempPreflight(root, config, readmeNext);
+
+  const files = [current.file, readmeFile, ...BUILD_OUTPUTS.map(relative => path.join(root, relative))];
+  const snapshot = new Map(files.map(file => [file, snapshotOf(file)]));
+  // Refuse a concurrent edit between the in-memory read and the completed preflight.
+  if (differs(current.file, { existed: true, value: current.raw }) || differs(readmeFile, { existed: true, value: readmeRaw })) {
+    fail("an activation input changed during preflight");
+  }
+
+  const tokenNext = Buffer.from(JSON.stringify(config, null, 2) + "\n", "utf8");
+  try {
+    atomicReplace(current.file, tokenNext);
+    atomicReplace(readmeFile, readmeNext);
+    runNode(path.join(root, "tools", "build.mjs"), [], root);
+    verifyRendered(root, config, readmeNext);
+    if (BUILD_OUTPUTS.some(relative => !sameBytes(bytes(path.join(root, relative)), proposed.get(relative)))) {
+      fail("the real build does not reproduce the completed temporary preflight");
+    }
+  } catch (error) {
+    try { restore(snapshot); }
+    catch (rollbackError) { throw rollbackError; }
+    throw error;
+  }
+
+  const changed = !sameBytes(current.raw, tokenNext) || !sameBytes(readmeRaw, readmeNext) ||
+    BUILD_OUTPUTS.some(relative => differs(path.join(root, relative), snapshot.get(path.join(root, relative))));
+  return { address: config.address, pons: config.pons, changed };
+}
+
+export async function runCli(argv = process.argv.slice(2), io = {}) {
+  const output = io.output || process.stdout;
+  const errorOutput = io.errorOutput || process.stderr;
+  if (!Array.isArray(argv) || argv.length !== 2) {
+    errorOutput.write("usage: activate-token <CA> <PONS_HTTPS_URL>\n");
+    return 1;
+  }
+  try {
+    const result = await activateToken(argv[0], argv[1]);
+    output.write(`activate-token: ${result.changed ? "prepared" : "already prepared"} ${result.address}\n`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof ActivationFailure ? error.message : "unexpected local failure";
+    errorOutput.write("activate-token: failed: " + message + "\n");
+    return 1;
+  }
+}
+
+const main = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (main) process.exitCode = await runCli();


### PR DESCRIPTION
Adds a fail-closed activation command for the future CA and Pons URL. It binds every on-chain proof to one finalized block, verifies the exact LINTCHA symbol and URL/address match, reproduces the build before writing, rolls back failed writes, and keeps dormant and active repository gates valid. No token is activated in this PR.