### PR TITLE
Add GitHub contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Report a reproducible problem in the site, tools, API worker or bot.
+title: "[bug] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for making the report reproducible. Do not include credentials, private RPC URLs, bot tokens, wallet secrets or signatures.
+        This is a public form. Do not use it for a suspected vulnerability or unpublished exploit details; no private reporting channel is currently published.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - Static site
+        - Build or verification tools
+        - API worker or bot
+        - Published data
+        - Documentation
+    validations:
+      required: true
+  - type: textarea
+    id: observed
+    attributes:
+      label: What happened?
+      description: Include the exact public URL or command and the complete non-secret error text.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Minimal reproduction
+      description: List the smallest sequence that reproduces the problem from a clean checkout or public page.
+    validations:
+      required: true
+  - type: input
+    id: revision
+    attributes:
+      label: Revision or observation time
+      description: Give the commit hash you tested, or the UTC time if this was observed on the public deployment.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser and version, or operating system and Node.js version, when relevant.
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety check
+      options:
+        - label: I removed credentials, private endpoints, wallet secrets, signatures and unpublished vulnerability details from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/product_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/product_proposal.yml
@@ -1,0 +1,50 @@
+name: Product proposal
+description: Propose a source-first improvement that preserves the product boundary.
+title: "[proposal] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Start with the user problem and the public source the repository can reproduce. The eight `road.never` statements are constraints, not optional styling.
+  - type: textarea
+    id: problem
+    attributes:
+      label: User problem
+      description: What becomes clearer, faster or more useful for a reader?
+    validations:
+      required: true
+  - type: textarea
+    id: source
+    attributes:
+      label: Verifiable source
+      description: Name the exact public input the repository would read. Do not include a credential-bearing URL.
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Proposed output
+      description: Describe what the site or bot would say and what it would explicitly refuse to claim.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction and tests
+      description: Explain how a clean checkout can reproduce the result and how failure remains visible.
+    validations:
+      required: true
+  - type: textarea
+    id: boundary
+    attributes:
+      label: Product-boundary review
+      description: Identify every `road.never` line the proposal touches, or state why it touches none.
+    validations:
+      required: true
+  - type: checkboxes
+    id: acknowledgement
+    attributes:
+      label: Acknowledgement
+      options:
+        - label: This proposal does not add a score, recommendation, private index, hosted key or unprovable figure.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+Describe the one concern this pull request changes and the user-visible outcome.
+
+## Evidence
+
+Name the source of every new public fact and any limit the implementation cannot prove.
+
+## Product boundary
+
+- [ ] All eight `road.never` statements are unchanged.
+- [ ] Vendored files are untouched, or the fix landed in lintcha first and `VENDOR.md` records the copied source.
+- [ ] No credential, private endpoint, bot token, wallet secret or signature appears in code, fixtures, logs or the pull request.
+- [ ] No figure, address, name, path or deployment fact is presented without a reproducible source.
+- [ ] Generated files were produced by their checked-in tool rather than edited by hand.
+
+## Checks
+
+List the exact commands run and their results. The required GitHub checks must pass for this pull request's exact head
+commit before merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+lintcha-chain is source-first: the repository must be able to reproduce every reading the public site makes. A
+change that weakens one of the eight `road.never` statements changes the product rather than extending it.
+
+## Before proposing a change
+
+- Use the issue forms for a reproducible bug or a product proposal.
+- Do not post credentials, private RPC URLs, bot tokens, wallet secrets, signatures or unpublished vulnerability
+  details in an issue, pull request, fixture or log.
+- Keep the snapshot comparison about self-declared strings. It does not inspect a contract, compute a price, assign a
+  score or make a recommendation.
+- Do not edit a vendored file in place. `VENDOR.md` identifies those files and their source commits; a fix belongs in
+  lintcha first and is copied here with an updated row.
+- Do not hand-edit generated comparison files. `npm run build` writes the generated HTML, sitemap and integrity
+  manifest from their authored inputs.
+
+## Local checks
+
+Use the Node.js version declared in `package.json`. The root package has no runtime dependencies.
+
+Run the checks relevant to the files you changed:
+
+```text
+npm test
+npm ci --prefix bot
+npm test --prefix bot
+npm run bundle --prefix bot
+npm run i18n
+npm run build
+node tools/verify-vendor.mjs
+```
+
+After a build, confirm that only the generated files you intended to update changed. The pull request workflows run
+the complete root and bot suites, translation check, deterministic build, browser contracts and vendor verification.
+
+The collection and publication workflow is deliberately manual and fail-closed. Do not run it merely to make a test
+green, and never replace a missing historical read with a guessed value.
+
+## Pull requests
+
+Keep one concern per pull request. Describe the source of every new public fact, the exact checks you ran and any
+limit the change cannot prove. A pull request is merged only after the required `test` and `verify-vendor` checks pass
+for its exact head commit.


### PR DESCRIPTION
Adds a concise contribution guide, structured bug and product-proposal forms, and a pull-request checklist. The templates encode the existing source-first, vendor, never-line and secret-handling boundaries. Security policy is deliberately excluded because no verified private reporting channel is currently enabled.