### PR TITLE
automation: add guarded Hour-X activation

### DIFF
--- a/.github/workflows/hour-x.yml
+++ b/.github/workflows/hour-x.yml
@@ -1,0 +1,236 @@
+# hour-x: turn the dormant public token document into one chain-proved pons-only activation.
+# The operator supplies only the two public values. The RPC endpoint remains a repository secret, is required rather
+# than allowed to fall back, and exists in the environment of the activation step only. The job never prints either
+# public input: they belong in the reviewed diff, not in workflow logs, commit metadata or PR prose.
+name: hour-x
+
+on:
+  workflow_dispatch:
+    inputs:
+      contract_address:
+        description: Public token contract address
+        required: true
+        type: string
+      pons_url:
+        description: Public canonical Pons HTTPS URL containing that address
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: hour-x
+  cancel-in-progress: false
+
+jobs:
+  activate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the dispatched revision without retaining credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Use the repository's pinned Node major
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24"
+
+      - name: Pin this run to the exact clean main revision
+        id: base
+        shell: bash
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "abort: Hour-X must be dispatched from main"
+            exit 1
+          fi
+          head_sha=$(git rev-parse HEAD)
+          if [ "${head_sha}" != "${GITHUB_SHA}" ]; then
+            echo "abort: checkout HEAD does not match the dispatched revision"
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          if [ "${head_sha}" != "$(git rev-parse origin/main)" ]; then
+            echo "abort: main moved before Hour-X began; dispatch again from the new main"
+            exit 1
+          fi
+          if [ -n "$(git status --porcelain=v1 --untracked-files=all)" ]; then
+            echo "abort: checkout is not clean before Hour-X"
+            exit 1
+          fi
+          echo "sha=${head_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify the vendored boundary before activation
+        run: node tools/verify-vendor.mjs
+
+      - name: Validate and mask the public inputs without printing them
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          import path from "node:path";
+          import { tokenConfigOf } from "./lib/config-contract.mjs";
+
+          const fail = () => {
+            process.stderr.write("abort: Hour-X inputs do not match the public activation contract\n");
+            process.exit(1);
+          };
+          let event;
+          try { event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8")); }
+          catch { fail(); }
+          const address = event && event.inputs && event.inputs.contract_address;
+          const pons = event && event.inputs && event.inputs.pons_url;
+          const config = tokenConfigOf({ address, pons, uniswap: null });
+          if (!config || !config.address || !config.pons || config.uniswap !== null) fail();
+          const commandValue = value => value.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+          for (const value of new Set([address, config.address, pons, config.pons])) {
+            process.stdout.write(`::add-mask::${commandValue(value)}\n`);
+          }
+          fs.writeFileSync(path.join(process.env.RUNNER_TEMP, "hour-x-ca.txt"), config.address + "\n", { flag: "wx", mode: 0o600 });
+          fs.writeFileSync(path.join(process.env.RUNNER_TEMP, "hour-x-pons.txt"), config.pons + "\n", { flag: "wx", mode: 0o600 });
+          NODE
+
+      - name: Prove and prepare the pons-only activation without logging its inputs
+        env:
+          LINTCHA_CHAIN_RPC_URL: ${{ secrets.LINTCHA_CHAIN_RPC_URL }}
+        shell: bash
+        run: |
+          cleanup_inputs() {
+            rm -f -- "${RUNNER_TEMP}/hour-x-ca.txt" "${RUNNER_TEMP}/hour-x-pons.txt"
+          }
+          trap cleanup_inputs EXIT
+          if [ -z "${LINTCHA_CHAIN_RPC_URL:-}" ]; then
+            echo "abort: the LINTCHA_CHAIN_RPC_URL repository secret is not configured"
+            exit 1
+          fi
+          IFS= read -r HOUR_X_CA < "${RUNNER_TEMP}/hour-x-ca.txt"
+          IFS= read -r HOUR_X_PONS_URL < "${RUNNER_TEMP}/hour-x-pons.txt"
+          node tools/activate-token.mjs "${HOUR_X_CA}" "${HOUR_X_PONS_URL}" > /dev/null
+
+      - name: Recheck the product boundary after activation
+        run: |
+          node tests/chain_token_states.mjs
+          node tools/verify-vendor.mjs
+
+      - name: Commit only status-derived activation files and open the guarded review
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          if [ "$(git rev-parse HEAD)" != "${BASE_SHA}" ]; then
+            echo "abort: local HEAD moved during activation"
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          if [ "${BASE_SHA}" != "$(git rev-parse origin/main)" ]; then
+            echo "abort: main moved during activation; discard these generated bytes and dispatch again"
+            exit 1
+          fi
+
+          status_file="${RUNNER_TEMP}/hour-x-status.txt"
+          paths_file="${RUNNER_TEMP}/hour-x-paths.txt"
+          staged_file="${RUNNER_TEMP}/hour-x-staged.txt"
+          git status --porcelain=v1 --untracked-files=all > "${status_file}"
+          if [ ! -s "${status_file}" ]; then
+            echo "abort: activation produced no reviewable change"
+            exit 1
+          fi
+          while IFS= read -r status_line; do
+            case "${status_line}" in
+              " M README.md"|" M site/token.json"|" M site/index.html"|" M site/es/index.html"|" M site/pt/index.html"|" M site/404.html") ;;
+              *)
+                echo "abort: activation changed a path outside its exact authored and generated allowlist"
+                exit 1
+                ;;
+            esac
+          done < "${status_file}"
+          for required_path in README.md site/token.json site/index.html site/es/index.html site/pt/index.html site/404.html; do
+            if ! grep -Fqx " M ${required_path}" "${status_file}"; then
+              echo "abort: activation did not modify every required authored and rendered path"
+              exit 1
+            fi
+          done
+          git diff --check > /dev/null
+          sed 's/^ M //' "${status_file}" | sort > "${paths_file}"
+
+          gh auth setup-git --hostname github.com > /dev/null
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add --pathspec-from-file="${paths_file}"
+          git diff --cached --name-only | sort > "${staged_file}"
+          if ! cmp -s "${paths_file}" "${staged_file}" || ! git diff --quiet; then
+            echo "abort: the staged paths do not exactly equal the status-derived allowlist"
+            exit 1
+          fi
+          git commit -m "token: guarded Hour-X activation" > /dev/null
+          generated_sha=$(git rev-parse HEAD)
+          if [ -n "$(git status --porcelain=v1 --untracked-files=all)" ]; then
+            echo "abort: the generated activation commit did not leave a clean tree"
+            exit 1
+          fi
+
+          branch="automation/hour-x-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git push origin "HEAD:refs/heads/${branch}" > /dev/null
+          pr_url=$(gh pr create --draft --base main --head "${branch}" --title "token: guarded Hour-X activation" --body "Manual Hour-X activation prepared by the repository guard. This draft contains only the public activation document, README line and deterministic localized build outputs. It becomes ready only after the explicitly dispatched test and vendor workflows pass for its unchanged head while main remains unchanged.")
+
+          gh workflow run test.yml --ref "${branch}" > /dev/null
+          gh workflow run vendor.yml --ref "${branch}" > /dev/null
+          test_run=""
+          vendor_run=""
+          for attempt in $(seq 1 30); do
+            if [ -z "${test_run}" ]; then
+              test_run=$(gh run list --workflow test.yml --branch "${branch}" --commit "${generated_sha}" --event workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+            fi
+            if [ -z "${vendor_run}" ]; then
+              vendor_run=$(gh run list --workflow vendor.yml --branch "${branch}" --commit "${generated_sha}" --event workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+            fi
+            if [ -n "${test_run}" ] && [ -n "${vendor_run}" ]; then break; fi
+            sleep 2
+          done
+          if [ -z "${test_run}" ] || [ -z "${vendor_run}" ]; then
+            echo "abort: both required workflow-dispatch runs were not observable for the generated head"
+            exit 1
+          fi
+          gh run watch "${test_run}" --exit-status > /dev/null
+          gh run watch "${vendor_run}" --exit-status > /dev/null
+          for run_id in "${test_run}" "${vendor_run}"; do
+            if [ "$(gh run view "${run_id}" --json headSha --jq '.headSha')" != "${generated_sha}" ] ||
+               [ "$(gh run view "${run_id}" --json event --jq '.event')" != "workflow_dispatch" ] ||
+               [ "$(gh run view "${run_id}" --json conclusion --jq '.conclusion')" != "success" ]; then
+              echo "abort: a required workflow did not pass for the exact generated head"
+              exit 1
+            fi
+          done
+
+          git fetch --no-tags origin main
+          remote_head=$(git ls-remote origin "refs/heads/${branch}" | awk 'NR == 1 { print $1 }')
+          pr_head=$(gh pr view "${pr_url}" --json headRefOid --jq '.headRefOid')
+          pr_branch=$(gh pr view "${pr_url}" --json headRefName --jq '.headRefName')
+          pr_base=$(gh pr view "${pr_url}" --json baseRefName --jq '.baseRefName')
+          pr_draft=$(gh pr view "${pr_url}" --json isDraft --jq '.isDraft')
+          if [ "${BASE_SHA}" != "$(git rev-parse origin/main)" ] ||
+             [ "${remote_head}" != "${generated_sha}" ] || [ "${pr_head}" != "${generated_sha}" ] ||
+             [ "${pr_branch}" != "${branch}" ] || [ "${pr_base}" != "main" ] || [ "${pr_draft}" != "true" ]; then
+            echo "abort: main, the automation branch or the draft PR moved while its exact head was tested"
+            exit 1
+          fi
+
+          gh pr ready "${pr_url}" > /dev/null
+          git fetch --no-tags origin main
+          final_remote_head=$(git ls-remote origin "refs/heads/${branch}" | awk 'NR == 1 { print $1 }')
+          final_pr_head=$(gh pr view "${pr_url}" --json headRefOid --jq '.headRefOid')
+          if [ "${BASE_SHA}" != "$(git rev-parse origin/main)" ] ||
+             [ "${final_remote_head}" != "${generated_sha}" ] || [ "${final_pr_head}" != "${generated_sha}" ]; then
+            gh pr ready --undo "${pr_url}" > /dev/null 2>&1 || true
+            echo "abort: main or the PR head moved while the PR was being marked ready"
+            exit 1
+          fi
+          if [ "$(gh pr view "${pr_url}" --json isDraft --jq '.isDraft')" != "false" ]; then
+            echo "abort: the guarded PR did not become ready"
+            exit 1
+          fi
+          echo "hour-x: guarded PR ready; both required workflows passed for its unchanged head and main remained unchanged"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center"><img src="assets/avatar.png" width="128" height="128" alt=""></p>
 <p align="center"><img src="assets/banner.png" alt="lintcha-chain" width="100%"></p>
 <p align="center">
-<img alt="tests" src="https://img.shields.io/badge/tests-2250_passing-d4fc50?labelColor=08090a&style=flat-square">
+<img alt="tests" src="https://img.shields.io/badge/tests-2292_passing-d4fc50?labelColor=08090a&style=flat-square">
 <img alt="node" src="https://img.shields.io/badge/node-%3E%3D24-5e5a53?labelColor=08090a&style=flat-square">
 <img alt="runtime deps" src="https://img.shields.io/badge/runtime_deps-0-5e5a53?labelColor=08090a&style=flat-square">
 <img alt="chain" src="https://img.shields.io/badge/chain-4663-5e5a53?labelColor=08090a&style=flat-square">
@@ -80,6 +80,7 @@ npm run i18n      merge the strings and run the vendored i18n check (three langu
 npm run verify    refuse the current legacy snapshot before network; for a state-pinned replacement, audit its exact state/window, rebuild, print both hashes
 node tests/published_contract_test.mjs     verify the manifest against the exact index and numbers bytes
 node tests/chain_browser.mjs site --pages "/,/es/,/pt/,/live/,/deployer/,/hold/,/hold/?t=0123456789abcdef0123456789abcdef"     all rendered-page and holder-flow contracts in a headless browser
+node tests/hour_x_workflow_test.mjs     check the manual activation workflow's inputs, secret boundary, exact files, race guards and PR review sequence
 npm run identity -- doctor     run the public conformance fixture
 node tools/collection-guard.mjs --in <report.json> --published site/launch-numbers.json --diagnose-semantic     reconstruct identities at the report's exact recorded state; this skips event-header batches and sampled transactions and is not publication proof
 npm run identity -- help       print the offline JSON CLI contract
@@ -138,7 +139,7 @@ The badges above are static images from shields.io, which GitHub renders; nothin
 Each figure is read from the tree, not typed from memory:
 
 ```
-tests           npm test; npm test --prefix bot              818 root checks + 1432 bot checks = 2250 checks
+tests           npm test; npm test --prefix bot              860 root checks + 1432 bot checks = 2292 checks
 node            package.json, engines.node                  >=24
 runtime deps    package.json                                no "dependencies" key
 chain           site/launch-numbers.json, chain_id          4663
@@ -192,6 +193,14 @@ At Hour X, run the guarded pons-only switch with the two public values:
 ```
 npm run activate-token -- <CA> <PONS_HTTPS_URL>
 ```
+
+For the hosted path, `.github/workflows/hour-x.yml` exposes those same two public values as a manual form. It requires
+`LINTCHA_CHAIN_RPC_URL` as a repository secret, masks the supplied values before handing them to the activation step,
+never prints the inputs or endpoint, and refuses a run outside the exact current `main`. It accepts exactly the activation document,
+README line, root comparison and 404, and the Spanish and Portuguese comparison pages as changes. Those paths are
+taken from `git status`, not a handwritten staging command. The workflow opens a draft PR, explicitly dispatches and
+waits for both required review workflows on the generated commit, rechecks `main`, the remote branch and the PR head,
+and only then marks the PR ready. It never merges or deploys.
 
 Before changing the tree it validates the shared config contract and URL/address binding, proves the configured
 endpoint's chain, reads one canonical finalized header, and uses that header's exact numeric block tag for token code,

--- a/VENDOR.md
+++ b/VENDOR.md
@@ -104,3 +104,4 @@ A path is added here in the same commit that creates the file.
 - `tests/collection_guard_test.mjs`
 - `tests/production_smoke_test.mjs`
 - `tests/activate_token_test.mjs`
+- `tests/hour_x_workflow_test.mjs`

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "node tools/build.mjs",
     "verify": "node tools/verify-index.mjs",
     "smoke:production": "node tools/production-smoke.mjs",
-    "test": "node tools/verify-vendor.mjs && node tests/config_contract_test.mjs && node tests/published_contract_test.mjs && node tests/chain_token_states.mjs && node tests/activate_token_test.mjs && node tests/live_wall_test.mjs && node tests/deployer_history_test.mjs && node tests/launch_test.js && node tests/launch_abi_test.mjs && node tests/launch_collector_state_test.mjs && node tests/launch_gate_test.mjs && node tests/collection_guard_test.mjs && node tests/launch_index_test.mjs && node tests/identity_cli_test.mjs && node tests/production_smoke_test.mjs",
+    "test": "node tools/verify-vendor.mjs && node tests/config_contract_test.mjs && node tests/published_contract_test.mjs && node tests/chain_token_states.mjs && node tests/activate_token_test.mjs && node tests/hour_x_workflow_test.mjs && node tests/live_wall_test.mjs && node tests/deployer_history_test.mjs && node tests/launch_test.js && node tests/launch_abi_test.mjs && node tests/launch_collector_state_test.mjs && node tests/launch_gate_test.mjs && node tests/collection_guard_test.mjs && node tests/launch_index_test.mjs && node tests/identity_cli_test.mjs && node tests/production_smoke_test.mjs",
     "activate-token": "node tools/activate-token.mjs",
     "identity": "node tools/identity.mjs",
     "i18n": "node tools/i18n-merge.mjs && node src/tools/i18n_check.js"

--- a/tests/hour_x_workflow_test.mjs
+++ b/tests/hour_x_workflow_test.mjs
@@ -1,0 +1,117 @@
+// Static security contract for the manual Hour-X workflow. This test never invokes git, GitHub, an RPC endpoint or
+// the activation itself; it makes the workflow's authority, secret boundary, exact changed-file set and review
+// sequence explicit enough that a casual YAML edit cannot quietly weaken them.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const file = path.join(root, ".github", "workflows", "hour-x.yml");
+let checks = 0, failures = 0;
+const ok = (condition, what) => {
+  checks++;
+  if (!condition) { failures++; console.log("  FAIL " + what); }
+};
+const count = (text, value) => text.split(value).length - 1;
+const sorted = values => [...values].sort();
+const same = (actual, expected) => JSON.stringify(sorted(actual)) === JSON.stringify(sorted(expected));
+const between = (text, start, end) => {
+  const from = text.indexOf(start);
+  if (from < 0) return "";
+  const to = text.indexOf(end, from + start.length);
+  return to < 0 ? text.slice(from) : text.slice(from, to);
+};
+
+const workflow = fs.existsSync(file) ? fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n") : "";
+const code = workflow.split("\n").filter(line => !line.trimStart().startsWith("#")).join("\n");
+const trigger = /^on:\n([\s\S]*?)^permissions:/m.exec(code)?.[1] || "";
+const permissionBlock = /^permissions:\n((?:  [^\n]+\n)+)/m.exec(code)?.[1] || "";
+const permissionRows = Object.fromEntries([...permissionBlock.matchAll(/^  ([a-z-]+): ([a-z]+)$/gm)].map(match => [match[1], match[2]]));
+const inputNames = [...trigger.matchAll(/^      ([a-z_]+):$/gm)].map(match => match[1]);
+const inputBlock = name => new RegExp(`^      ${name}:\\n((?:        [^\\n]+\\n)+)`, "m").exec(trigger)?.[1] || "";
+const prep = between(code, "      - name: Validate and mask the public inputs without printing them", "      - name: Prove and prepare");
+const activation = between(code, "      - name: Prove and prepare the pons-only activation without logging its inputs", "      - name: Recheck the product boundary");
+const review = between(code, "      - name: Commit only status-derived activation files and open the guarded review", "\n\u0000");
+const statusCase = between(review, '            case "${status_line}" in', "            esac");
+const allowedPaths = [...statusCase.matchAll(/" M ([^"]+)"/g)].map(match => match[1]);
+const requiredPaths = /for required_path in ([^;]+); do/.exec(review)?.[1].trim().split(/\s+/) || [];
+const exactChangedPaths = [
+  "README.md",
+  "site/404.html",
+  "site/es/index.html",
+  "site/index.html",
+  "site/pt/index.html",
+  "site/token.json"
+];
+
+ok(workflow.length > 0 && !workflow.includes("\t"), "the workflow exists and uses YAML spaces, not tabs");
+ok(/^name: hour-x$/m.test(code), "the workflow has the stable hour-x name");
+ok(same([...trigger.matchAll(/^  ([a-z_]+):$/gm)].map(match => match[1]), ["workflow_dispatch"]), "workflow_dispatch is the only trigger");
+ok(same(inputNames, ["contract_address", "pons_url"]), "the manual form has exactly the two public inputs");
+for (const name of ["contract_address", "pons_url"]) {
+  const block = inputBlock(name);
+  ok(/^        description: \S.+$/m.test(block) && /^        required: true$/m.test(block) && /^        type: string$/m.test(block) && !/^        default:/m.test(block),
+    `${name} is a required string with no stored default`);
+}
+ok(JSON.stringify(permissionRows) === JSON.stringify({ contents: "write", "pull-requests": "write", actions: "write" }) && count(code, "permissions:") === 1,
+  "the token has only the three explicit write scopes and no job override");
+ok(/^concurrency:\n  group: hour-x\n  cancel-in-progress: false$/m.test(code), "concurrent Hour-X runs serialize without cancellation");
+
+const uses = [...code.matchAll(/^\s*uses: (\S+)$/gm)].map(match => match[1]);
+ok(uses.length === 2 && uses.every(value => /^actions\/(?:checkout|setup-node)@[0-9a-f]{40}$/.test(value)), "both external actions are pinned by full commit SHA");
+ok(/uses: actions\/checkout@[0-9a-f]{40}\n        with:\n          persist-credentials: false/.test(code), "checkout never persists the write credential");
+ok(/uses: actions\/setup-node@[0-9a-f]{40}\n        with:\n          node-version: "24"/.test(code), "the workflow uses the repository's pinned Node major");
+
+ok(!code.includes("${{ inputs.") && !code.includes("${{ github.event.inputs."), "raw workflow expressions never interpolate public inputs into a step");
+ok(prep.includes("process.env.GITHUB_EVENT_PATH") && prep.includes("event.inputs.contract_address") && prep.includes("event.inputs.pons_url"), "input preparation reads only the event file and both declared values");
+ok(prep.includes('import { tokenConfigOf } from "./lib/config-contract.mjs"') && prep.includes("tokenConfigOf({ address, pons, uniswap: null })") && !prep.includes("1024") && !prep.includes("new URL("), "input validation reuses the shared activation contract without duplicated limits or URL rules");
+ok(prep.includes('replace(/%/g, "%25")') && prep.includes("::add-mask::") && prep.indexOf("::add-mask::") < prep.indexOf("fs.writeFileSync"), "raw and canonical values are command-escaped and masked before leaving validation");
+ok(count(prep, 'mode: 0o600') === 2 && prep.includes('"hour-x-ca.txt"), config.address + "\\n"') && prep.includes('"hour-x-pons.txt"), config.pons + "\\n"') && !prep.includes("GITHUB_OUTPUT"), "only canonical masked inputs enter two fixed private runner-temp files with readable line termination");
+
+const secretExpression = "${{ secrets.LINTCHA_CHAIN_RPC_URL }}";
+ok(count(code, secretExpression) === 1 && activation.includes(secretExpression), "the RPC secret is referenced exactly once, only by the activation step");
+ok(!code.replace(activation, "").includes("LINTCHA_CHAIN_RPC_URL"), "the RPC setting does not escape the activation step");
+const requireSecretAt = activation.indexOf('if [ -z "${LINTCHA_CHAIN_RPC_URL:-}" ]');
+const invokeAt = activation.indexOf('node tools/activate-token.mjs "${HOUR_X_CA}" "${HOUR_X_PONS_URL}" > /dev/null');
+ok(requireSecretAt >= 0 && invokeAt > requireSecretAt, "an empty repository secret fails before the guarded activator runs");
+ok(activation.includes('IFS= read -r HOUR_X_CA < "${RUNNER_TEMP}/hour-x-ca.txt"') && activation.includes('IFS= read -r HOUR_X_PONS_URL < "${RUNNER_TEMP}/hour-x-pons.txt"') && activation.includes("trap cleanup_inputs EXIT"), "the masked inputs are read without printing and removed on every activation exit");
+ok(invokeAt >= 0 && !code.includes("npm run activate-token"), "the activator's stdout and npm's argument echo cannot enter the log");
+ok(!/set\s+-x|printenv|toJSON\s*\(|::debug::|::notice::|upload-artifact/i.test(code) && !/(?:echo|printf)[^\n]*\$\{(?:HOUR_X_CA|HOUR_X_PONS_URL|LINTCHA_CHAIN_RPC_URL)/.test(code),
+  "the workflow has no tracing, environment dump, artifact upload or value-print command");
+
+const recheckAt = code.indexOf("node tests/chain_token_states.mjs");
+const vendorAfterAt = code.indexOf("node tools/verify-vendor.mjs", recheckAt);
+const statusAt = code.indexOf("git status --porcelain=v1 --untracked-files=all >");
+ok(recheckAt >= 0 && vendorAfterAt > recheckAt && statusAt > vendorAfterAt, "never digests and the vendor boundary are rechecked before status is trusted");
+ok(same(allowedPaths, exactChangedPaths) && allowedPaths.length === exactChangedPaths.length, "the case guard allows exactly the six activation modifications");
+ok(same(requiredPaths, exactChangedPaths) && requiredPaths.length === exactChangedPaths.length, "all six allowed modifications are required, so a no-op or partial build fails");
+ok(!statusCase.includes("sitemap") && !statusCase.includes("manifest") && !statusCase.includes("src/i18n"), "token-independent and ignored build outputs cannot enter the Hour-X commit");
+ok(review.includes("sed 's/^ M //' \"${status_file}\" | sort > \"${paths_file}\"") && review.includes('git add --pathspec-from-file="${paths_file}"') && count(review, "git add ") === 1,
+  "staging paths come only from the verified porcelain output");
+ok(review.includes('git diff --cached --name-only | sort > "${staged_file}"') && review.includes('cmp -s "${paths_file}" "${staged_file}"') && review.includes("git diff --quiet"), "the staged set is reproduced exactly and leaves no unstaged change");
+
+ok(code.includes('if [ "${GITHUB_REF}" != "refs/heads/main" ]') && code.includes('if [ "${head_sha}" != "${GITHUB_SHA}" ]'), "dispatch is pinned to main and its exact event revision");
+ok(count(code, "git fetch --no-tags origin main") >= 4 && count(code, "git rev-parse origin/main") >= 4 && review.includes('if [ "$(git rev-parse HEAD)" != "${BASE_SHA}" ]'), "main and local HEAD are guarded before mutation, before push and after review checks");
+ok(review.includes('git commit -m "token: guarded Hour-X activation"') && review.includes('branch="automation/hour-x-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"'), "commit and branch metadata are fixed and contain no public input");
+ok(review.includes('gh pr create --draft --base main --head "${branch}" --title "token: guarded Hour-X activation" --body "Manual Hour-X activation prepared by the repository guard.'), "the automation opens a fixed-prose draft PR against main");
+ok(!/(?:commit -m|--title|--body|branch=)[^\n]*(?:HOUR_X_CA|HOUR_X_PONS_URL|LINTCHA_CHAIN_RPC_URL|token\.json)/.test(review), "no input, secret or activated file is interpolated into branch, commit or PR metadata");
+
+for (const name of ["test", "vendor"]) {
+  ok(review.includes(`gh workflow run ${name}.yml --ref "\${branch}"`) &&
+     review.includes(`gh run list --workflow ${name}.yml --branch "\${branch}" --commit "\${generated_sha}" --event workflow_dispatch`),
+    `${name}.yml is explicitly dispatched and found only for the exact generated head`);
+}
+ok(review.includes('gh run watch "${test_run}" --exit-status') && review.includes('gh run watch "${vendor_run}" --exit-status'), "both required workflow runs must finish successfully");
+ok(review.includes('--json headSha') && review.includes('--json event') && review.includes('--json conclusion') && review.includes('!= "${generated_sha}"') && review.includes('!= "workflow_dispatch"') && review.includes('!= "success"'),
+  "each completed run is rechecked for exact head, event and successful conclusion");
+ok(review.includes('git ls-remote origin "refs/heads/${branch}"') && review.includes('--json headRefOid') && review.includes('--json headRefName') && review.includes('--json baseRefName') && review.includes('--json isDraft'),
+  "remote branch and draft PR identity are checked after CI");
+ok(count(review, 'gh pr ready "${pr_url}"') === 1 && review.indexOf('gh pr ready "${pr_url}"') > review.indexOf('gh run watch "${vendor_run}"') && review.includes('gh pr ready --undo "${pr_url}"'),
+  "the PR becomes ready only after CI and is returned to draft if the final race check fails");
+ok(!/gh pr merge|--auto|git push origin main|wrangler|deploy|release|git tag/i.test(review), "Hour-X neither merges nor deploys, releases or tags anything");
+ok(!prep.includes("GITHUB_OUTPUT") && !activation.includes("GITHUB_OUTPUT") && !/(HOUR_X_CA|HOUR_X_PONS_URL|LINTCHA_CHAIN_RPC_URL)[^\n]*GITHUB_OUTPUT|GITHUB_OUTPUT[^\n]*(HOUR_X_CA|HOUR_X_PONS_URL|LINTCHA_CHAIN_RPC_URL)/.test(code), "no public input or RPC setting reaches a workflow output");
+const outputLines = code.split("\n").filter(line => line.includes("GITHUB_OUTPUT"));
+ok(outputLines.length === 1 && outputLines[0].includes('echo "sha=${head_sha}"') && !code.includes("GITHUB_ENV"), "the exact base SHA is the only workflow output and no input is exported globally");
+
+console.log(`hour-x workflow: ${checks} checks, ${failures} failure(s)`);
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
Adds a manual two-input Hour-X workflow that consumes the archive RPC only from the repository secret, validates and masks inputs before handoff, runs the existing finalized-state activation guard, stages only the exact six status-derived activation paths, and opens a draft PR. It explicitly runs both required review workflows against the generated SHA, repeats main/branch/PR race checks, and never merges or deploys. Includes a focused static security regression contract; token.json remains dormant and all eight never lines remain unchanged.