### PR TITLE
api: expose guarded identity comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The comparison needs no account and no wallet. What you paste stays in the brows
 | [Deployer history](https://chain.lintcha.com/deployer/) | Renders bounded retained declarations for one public deployer address when watcher state is readable | Static page shipped; retained range only |
 | Fact receipts | Copies or downloads the exact input, rendered result and snapshot context locally | Shipped |
 | Integrity manifest | Binds the exact published index and numbers bytes with SHA-256 | Shipped |
-| Identity kit | Exposes the same normalization engine as an ESM library and offline JSON CLI | Shipped |
+| Identity kit | Exposes the same normalization engine as an ESM library, offline JSON CLI and opt-in HTTP API | Shipped |
 | Localized comparison | Builds the snapshot page in English, Spanish and Portuguese | Shipped |
 | Telegram, holder and feed code | Routes commands, verifies holder proofs and delivers finalized feed events | Shipped in code; token-dependent paths dormant before activation |
 
@@ -147,6 +147,8 @@ The first comparison fetches the index once from the same origin. Pasted fields 
 
 The site sets no cookie and loads no third-party script, font, image, analytics or beacon. URLs and logo URIs entered into the tool are compared as strings and are never opened by the comparison.
 
+The public site does not call `/api/identity`. That endpoint is an opt-in integration surface: a client that calls it sends the submitted strings to the Worker. The Worker keeps no identity request state, echoes no submitted declaration and answers from the same manifest-bound public index. Use the browser or offline kit when the strings must not cross the network.
+
 ## Developer commands
 
 ### Identity CLI
@@ -161,6 +163,18 @@ node tools/identity.mjs read --input ./identity.json
 ```
 
 `read` uses the checked-in index and manifest by default. A custom index is refused unless its matching manifest is supplied.
+
+### Identity HTTP API
+
+`POST https://chain.lintcha.com/api/identity` accepts the same complete JSON input as `node tools/identity.mjs read` and returns the engine result with the verified corpus SHA-256, byte count and entry count. It requires `Content-Type: application/json`, stores nothing and never echoes submitted fields.
+
+```sh
+curl https://chain.lintcha.com/api/identity \
+  --header 'content-type: application/json' \
+  --data @identity.json
+```
+
+Successful responses use schema `lintcha-chain/identity-api/v1` and engine `LINTCHA_12`. Shape, media-type, rate-limit and unavailable-corpus failures are machine-readable and fail closed.
 
 ### Useful commands
 

--- a/bot/README.md
+++ b/bot/README.md
@@ -15,7 +15,7 @@ config and the bot's config cannot disturb each other.
 
     wrangler.toml     the worker: name, routes, bindings, migrations, the cron, the settings
     package.json      type module, the scripts, and one exact dev dependency: Wrangler 4.131.0
-    src/index.js      the worker. Five routes and a cron, and nothing else answers
+    src/index.js      the worker. Six routes and a cron, and nothing else answers
     src/router.js     the commands. Returns actions and sends nothing, so a test can read what it would say
     src/texts.js      every sentence the bot can say
     src/telegram.js   sending, and the small amount of markup
@@ -28,6 +28,7 @@ config and the bot's config cannot disturb each other.
     src/watch.js      the watcher: the launch log's live tail, and the rules read against it
     src/rules.js      what a holder asked to be told about, and whether a launch matches it
     src/engine.js     site/launch.js, loaded and never copied. See below
+    src/identity.js   the strict full-input boundary for the opt-in HTTP identity route
     src/engine-globals.js  the two vendored tables the engine needs, put where it looks for them
     src/tally.js      counting launches the way the collector counts them
     tools/verify-tail.mjs  rebuild the tail's block range with the collector and compare
@@ -231,7 +232,7 @@ covered against a `token.json` of three nulls and the feed sleeps, but the Teleg
 the public launch promise. That dormant state is distinct from the two Telegram credentials, which are required before
 the Worker deployment.
 
-## The five routes
+## The six routes
 
     POST /api/telegram   every update must carry X-Telegram-Bot-Api-Secret-Token matching
                          the secret. A wrong or missing header gets four hundred and one
@@ -242,6 +243,9 @@ the Worker deployment.
     POST /api/hold       the holder check, posted by the /hold page on the site. Same
                          origin, JSON media type and a bounded body are required before a separate
                          courtesy limit can let the request touch Watch
+    POST /api/identity   the same manifest-bound identity comparison as the page and offline kit,
+                         for integrations that explicitly choose to send their strings to the Worker;
+                         no request fields are stored or echoed
     GET/HEAD /api/tail   versioned, block-aligned committed pages of the public launch tail: ranges,
                          counts and hashes only; no raw name, ticker, address or private holder data
     GET/HEAD /api/wall   the public, strict post-snapshot suffix: bounded self-declared name
@@ -252,6 +256,13 @@ the Worker deployment.
 
 Anything else under `/api/` is four hundred and four. The site's own pages are untouched:
 the route is `/api/*` and the root stays with the assets worker.
+
+`/api/identity` is not used by the public comparison page. The page keeps its existing local-only path; the HTTP
+route is an opt-in network boundary for integrations. It accepts only the complete documented identity shape,
+uses `site/launch.js` rather than another normalizer, verifies `launch-index.json` against the published manifest,
+and returns the same corpus receipt as the offline CLI. Malformed requests never reach the Durable Object, and
+the successful path performs no SQLite or KV write. CORS is public, responses are `no-store`, and an independent
+per-isolate courtesy bucket can be tightened with `IDENTITY_PER_SECOND`.
 
 ## The holder check
 
@@ -630,6 +641,9 @@ Telegram, KV and both Durable Object contexts are local fakes from `test/fakes.m
                    loaded a second time the way the page loads it, and one fixture set through
                    both engines compared value for value, hash for hash, entry for entry, and
                    through check() itself
+    identity_api_test   strict full-input and media boundaries, bounded ingress, CORS, independent
+                   rate limiting, manifest-bound corpus reads, exact engine result, no durable write
+                   and no reflection of submitted declarations
     rules_test     a string rule fires on a match and is otherwise silent, a dev rule on that
                    deployer and no other, a shared rule at the threshold and not one below,
                    and one person's rule is not removable by another

--- a/bot/package.json
+++ b/bot/package.json
@@ -8,7 +8,7 @@
     "node": ">=24"
   },
   "scripts": {
-    "test": "node test/keccak_test.mjs && node test/nonce_test.mjs && node test/verify_test.mjs && node test/router_test.mjs && node test/webhook_test.mjs && node test/telegram_bootstrap_test.mjs && node test/chain_test.mjs && node test/tape_test.mjs && node test/texts_test.mjs && node test/predeploy_test.mjs && node test/engine_test.mjs && node test/rules_test.mjs && node test/watch_test.mjs && node test/tail_test.mjs && node test/wall_test.mjs && node test/history_test.mjs && node test/rules_router_test.mjs",
+    "test": "node test/keccak_test.mjs && node test/nonce_test.mjs && node test/verify_test.mjs && node test/router_test.mjs && node test/webhook_test.mjs && node test/telegram_bootstrap_test.mjs && node test/chain_test.mjs && node test/tape_test.mjs && node test/texts_test.mjs && node test/predeploy_test.mjs && node test/engine_test.mjs && node test/identity_api_test.mjs && node test/rules_test.mjs && node test/watch_test.mjs && node test/tail_test.mjs && node test/wall_test.mjs && node test/history_test.mjs && node test/rules_router_test.mjs",
     "verify-tail": "node tools/verify-tail.mjs",
     "check-config": "node tools/predeploy.mjs",
     "check-config:production": "node tools/predeploy.mjs --production",

--- a/bot/src/identity.js
+++ b/bot/src/identity.js
@@ -1,0 +1,33 @@
+// The HTTP identity boundary. It validates the documented full input before the request reaches the watcher;
+// normalization and comparison remain in site/launch.js, imported through engine.js, and are not copied here.
+
+import { LINKS } from "./engine.js";
+
+export const ENGINE_ID = "LINTCHA_12";
+export const IDENTITY_API_SCHEMA = "lintcha-chain/identity-api/v1";
+export const IDENTITY_INPUT_FIELDS = Object.freeze([
+  "name",
+  "ticker",
+  "description",
+  "links",
+  "logo",
+  "recipient"
+]);
+export const IDENTITY_LINK_FIELDS = Object.freeze([...LINKS]);
+
+const record = value => !!value && typeof value === "object" && !Array.isArray(value);
+const exactFields = (value, fields) => {
+  if (!record(value)) return false;
+  const keys = Object.keys(value);
+  return keys.length === fields.length && fields.every(field => Object.prototype.hasOwnProperty.call(value, field));
+};
+
+/** Return the accepted object itself, or null. Errors never reflect a submitted value. */
+export function identityInputOf(value) {
+  if (!exactFields(value, IDENTITY_INPUT_FIELDS)) return null;
+  for (const field of IDENTITY_INPUT_FIELDS) {
+    if (field !== "links" && typeof value[field] !== "string") return null;
+  }
+  if (!exactFields(value.links, IDENTITY_LINK_FIELDS)) return null;
+  return IDENTITY_LINK_FIELDS.every(field => typeof value.links[field] === "string") ? value : null;
+}

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -1,4 +1,4 @@
-// The worker. Five routes and a cron, and nothing else answers.
+// The worker. Six routes and a cron, and nothing else answers.
 //
 //   POST /api/telegram   the webhook. Every update must carry X-Telegram-Bot-Api-Secret-Token matching the
 //                        TELEGRAM_WEBHOOK_SECRET secret. A wrong or missing header gets four hundred and one
@@ -7,6 +7,8 @@
 //   POST /api/hold       the holder check, from the /hold page on the site. Same origin, which is why the
 //                        vendored connect-src 'self' needs no editing. The route requires that exact browser
 //                        origin and JSON media type before it touches the one global Watch object.
+//   POST /api/identity   an opt-in integration surface for the page's exact comparison. Unlike the browser
+//                        tool, an API call sends its strings to this Worker. They are not stored or echoed.
 //   GET  /api/tail       versioned, bounded pages of the live launch tail: counted hashes, an exact block range,
 //                        ordered chunk commitments and an opaque continuation cursor. Public, cached for a few
 //                        seconds, and rate limited per isolate. The page is
@@ -35,6 +37,7 @@ import * as T from "./texts.js";
 import { Tape } from "./tape.js";
 import { Watch, DEFAULT_TAIL_CACHE_MS, DEFAULT_INDEX_TTL_MS } from "./watch.js";
 import { integerSetting } from "./config.js";
+import { identityInputOf } from "./identity.js";
 
 export { Tape, Watch };
 
@@ -190,11 +193,13 @@ const tailBucket = { at: 0, taken: 0 };
 const wallBucket = { at: 0, taken: 0 };
 const historyBucket = { at: 0, taken: 0 };
 const holdBucket = { at: 0, taken: 0 };
+const identityBucket = { at: 0, taken: 0 };
 export const DEFAULT_API_PER_SECOND = 4;
 export const MAX_API_PER_SECOND = 100;
 /** Public request bodies are tiny protocol messages; these bounds are byte ceilings, not hints. */
 export const TELEGRAM_UPDATE_BODY_LIMIT = 64 * 1024;
 export const HOLD_BODY_LIMIT = 1024;
+export const IDENTITY_BODY_LIMIT = TELEGRAM_UPDATE_BODY_LIMIT;
 /** Inbound body reads share the watcher's existing bounded I/O window. */
 export const INBOUND_BODY_TIMEOUT_MS = DEFAULT_TAIL_CACHE_MS;
 /** Only for tests: forget what this second has already served. */
@@ -202,6 +207,7 @@ export function forgetTailBucket() { tailBucket.at = 0; tailBucket.taken = 0; }
 export function forgetWallBucket() { wallBucket.at = 0; wallBucket.taken = 0; }
 export function forgetHistoryBucket() { historyBucket.at = 0; historyBucket.taken = 0; }
 export function forgetHoldBucket() { holdBucket.at = 0; holdBucket.taken = 0; }
+export function forgetIdentityBucket() { identityBucket.at = 0; identityBucket.taken = 0; }
 function bucketAllowed(bucket, now, perSecond) {
   const second = Math.floor(now / 1000);
   if (bucket.at !== second) { bucket.at = second; bucket.taken = 0; }
@@ -232,6 +238,17 @@ const tailAllowed = (now, perSecond) => bucketAllowed(tailBucket, now, perSecond
 const wallAllowed = (now, perSecond) => bucketAllowed(wallBucket, now, perSecond);
 const historyAllowed = (now, perSecond) => bucketAllowed(historyBucket, now, perSecond);
 const holdAllowed = (now, perSecond) => bucketAllowed(holdBucket, now, perSecond);
+const identityAllowed = (now, perSecond) => bucketAllowed(identityBucket, now, perSecond);
+
+const identityHeaders = Object.freeze({
+  "content-type": "application/json",
+  "cache-control": "no-store",
+  "access-control-allow-origin": "*"
+});
+const identityJson = (value, status = 200, extra = {}) => new Response(JSON.stringify(value), {
+  status,
+  headers: { ...identityHeaders, ...extra }
+});
 
 const BODY_READ_TIMEOUT = Symbol("body read timeout");
 const cancelBestEffort = target => {
@@ -286,6 +303,42 @@ export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
     const path = url.pathname.replace(/\/+$/, "");
+
+    if (path === "/api/identity") {
+      if (request.method === "OPTIONS") {
+        return new Response(null, {
+          status: 204,
+          headers: {
+            "cache-control": "no-store",
+            "access-control-allow-origin": "*",
+            "access-control-allow-methods": "POST, OPTIONS",
+            "access-control-allow-headers": "content-type"
+          }
+        });
+      }
+      if (request.method !== "POST") return identityJson({ ok: false, why: "method" }, 405, { allow: "POST, OPTIONS" });
+      const mediaType = String(request.headers.get("content-type") || "").split(";", 1)[0].trim().toLowerCase();
+      if (mediaType !== "application/json") return identityJson({ ok: false, why: "media_type" }, 415);
+      if (!identityAllowed(Date.now(), configuredPerSecond(env.IDENTITY_PER_SECOND, env.TAIL_PER_SECOND))) {
+        return identityJson({ ok: false, why: "rate_limited" }, 429);
+      }
+      const body = await boundedJsonBody(request, IDENTITY_BODY_LIMIT);
+      const input = identityInputOf(body);
+      if (!input) return identityJson({ ok: false, why: "shape" }, 400);
+      const stub = watchStub(env);
+      if (!stub) return identityJson({ ok: false, why: "corpus_unavailable" }, 503);
+      try {
+        const response = await stub.fetch("https://watch/identity", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(input)
+        });
+        if (![200, 400, 503].includes(response.status)) return identityJson({ ok: false, why: "corpus_unavailable" }, 503);
+        return new Response(response.body, { status: response.status, headers: identityHeaders });
+      } catch {
+        return identityJson({ ok: false, why: "corpus_unavailable" }, 503);
+      }
+    }
 
     if (path === "/api/telegram") {
       if (request.method !== "POST") return new Response(null, { status: 405 });

--- a/bot/src/watch.js
+++ b/bot/src/watch.js
@@ -36,6 +36,7 @@ import * as TEXT from "./texts.js";
 import { validLaunchIndex, publishedManifestOf } from "../../lib/published-contract.mjs";
 import { requiredHttpsUrlOf } from "../../lib/config-contract.mjs";
 import { integerSetting } from "./config.js";
+import { ENGINE_ID, IDENTITY_API_SCHEMA, identityInputOf } from "./identity.js";
 
 export const DEFAULT_INTERVAL_MS = 12000;
 export const DEFAULT_WATCHDOG_MS = 90000;
@@ -434,6 +435,25 @@ export class Watch {
       if (!this.historyAllowed(now)) return json(wallFailure("rate_limited"), 429);
       const body = await this.deployerHistory(address, now);
       return json(body, body.ok ? 200 : 503);
+    }
+    if (path === "identity") {
+      if (request.method !== "POST") return new Response(null, { status: 405 });
+      const body = await request.json().catch(() => null);
+      if (!identityInputOf(body)) return json({ ok: false, why: "shape" }, 400);
+      const state = await this.manifestState(Date.now());
+      const index = state ? await this.index(Date.now()) : null;
+      if (!state || !index) return json({ ok: false, why: "corpus_unavailable" }, 503);
+      return json({
+        ok: true,
+        schema: IDENTITY_API_SCHEMA,
+        engine: ENGINE_ID,
+        corpus: {
+          sha256: state.value.index.sha256,
+          bytes: state.value.index.bytes,
+          entries_total: state.value.index.entries_total
+        },
+        result: await engineCheck(body, index)
+      });
     }
     if (path === "state") return json(await this.state());
     if (path === "nonce") {

--- a/bot/test/identity_api_test.mjs
+++ b/bot/test/identity_api_test.mjs
@@ -1,0 +1,120 @@
+// The opt-in HTTP adapter: strict shape, bounded ingress, the exact published corpus and no stored or echoed
+// declaration. The browser comparison remains separate and local.
+//   node test/identity_api_test.mjs
+
+import worker, { IDENTITY_BODY_LIMIT, forgetIdentityBucket } from "../src/index.js";
+import { check } from "../src/engine.js";
+import { ENGINE_ID, IDENTITY_API_SCHEMA, IDENTITY_INPUT_FIELDS, IDENTITY_LINK_FIELDS, identityInputOf } from "../src/identity.js";
+import { Watch, forgetPublished } from "../src/watch.js";
+import { emptyPublishedIndex, fakePublished, fakeWatchCtx, harness } from "./fakes.mjs";
+import { ENGINE_ID as KIT_ENGINE_ID, IDENTITY_INPUT_FIELDS as KIT_INPUT_FIELDS, IDENTITY_LINK_FIELDS as KIT_LINK_FIELDS } from "../../lib/identity.mjs";
+
+const t = harness("identity api");
+const input = {
+  name: "API marker that must not be echoed",
+  ticker: "API_MARKER",
+  description: "one two three four five six seven eight nine ten eleven twelve",
+  links: { twitter: "@api-marker", telegram: "", discord: "", website: "", farcaster: "" },
+  logo: "",
+  recipient: ""
+};
+const index = emptyPublishedIndex();
+const published = fakePublished({ index });
+
+t.ok(ENGINE_ID === KIT_ENGINE_ID, "the HTTP and offline kit name the same engine");
+t.ok(JSON.stringify(IDENTITY_INPUT_FIELDS) === JSON.stringify(KIT_INPUT_FIELDS) && JSON.stringify(IDENTITY_LINK_FIELDS) === JSON.stringify(KIT_LINK_FIELDS), "the HTTP and offline kit require the same fields");
+t.ok(identityInputOf(input) === input, "the documented full input shape is accepted");
+t.ok(identityInputOf({ ...input, extra: "not echoed" }) === null, "an extra top-level field is refused");
+const missing = { ...input };
+delete missing.ticker;
+t.ok(identityInputOf(missing) === null, "a missing top-level field is refused");
+t.ok(identityInputOf({ ...input, logo: null }) === null, "a non-string declaration is refused");
+t.ok(identityInputOf({ ...input, links: { ...input.links, matrix: "not echoed" } }) === null, "an extra link field is refused");
+t.ok(identityInputOf({ ...input, links: { ...input.links, website: null } }) === null, "a non-string link is refused");
+
+forgetPublished();
+const watchCtx = fakeWatchCtx();
+const watch = new Watch(watchCtx, {});
+const sqlBefore = watchCtx.storage.sql.calls.length;
+let response = await watch.fetch(new Request("https://watch/identity", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(input)
+}));
+const directText = await response.text();
+const direct = JSON.parse(directText);
+t.ok(response.status === 200 && direct.ok === true, "the Watch adapter answers a valid comparison");
+t.ok(direct.schema === IDENTITY_API_SCHEMA && direct.engine === ENGINE_ID, "the response names its API schema and engine");
+t.ok(JSON.stringify(direct.result) === JSON.stringify(await check(input, index)), "the result is the site engine's exact check");
+t.ok(direct.corpus && /^[0-9a-f]{64}$/.test(direct.corpus.sha256) && Number.isSafeInteger(direct.corpus.bytes) && Number.isSafeInteger(direct.corpus.entries_total), "the response carries the verified index receipt");
+t.ok(!directText.includes(input.name) && !directText.includes(input.ticker) && !directText.includes(input.links.twitter), "the response echoes no submitted declaration");
+t.ok(watchCtx.storage.sql.calls.length === sqlBefore, "an identity read writes no durable state");
+t.ok(published.asked.some(url => url.includes("launch-manifest.json")) && published.asked.some(url => url.includes("launch-index.json")), "the adapter reads the public manifest and index");
+
+response = await watch.fetch(new Request("https://watch/identity", { method: "POST", headers: { "content-type": "application/json" }, body: "{}" }));
+t.ok(response.status === 400 && JSON.stringify(await response.json()) === JSON.stringify({ ok: false, why: "shape" }), "the internal boundary refuses an invalid shape without reflecting it");
+
+forgetPublished();
+fakePublished({ index, manifestOk: false });
+response = await new Watch(fakeWatchCtx(), {}).fetch(new Request("https://watch/identity", {
+  method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(input)
+}));
+t.ok(response.status === 503 && (await response.json()).why === "corpus_unavailable", "an unreadable manifest fails closed");
+
+forgetPublished();
+fakePublished({ index });
+let watchCalls = 0;
+const binding = {
+  idFromName: () => "watch",
+  get: () => ({ fetch: (url, init) => {
+    watchCalls++;
+    return watch.fetch(url instanceof Request ? url : new Request(url, init));
+  } })
+};
+const env = { WATCH: binding, IDENTITY_PER_SECOND: "4" };
+const post = (body, headers = {}) => new Request("https://chain.lintcha.com/api/identity", {
+  method: "POST",
+  headers: { "content-type": "application/json", ...headers },
+  body: typeof body === "string" ? body : JSON.stringify(body)
+});
+
+forgetIdentityBucket();
+response = await worker.fetch(new Request("https://chain.lintcha.com/api/identity", { method: "OPTIONS" }), env, {});
+t.ok(response.status === 204 && response.headers.get("access-control-allow-origin") === "*" && response.headers.get("access-control-allow-methods") === "POST, OPTIONS", "the endpoint answers a minimal public CORS preflight");
+response = await worker.fetch(new Request("https://chain.lintcha.com/api/identity"), env, {});
+t.ok(response.status === 405 && response.headers.get("allow") === "POST, OPTIONS", "other methods are refused and the allowed methods are named");
+response = await worker.fetch(post("{}", { "content-type": "text/plain" }), env, {});
+t.ok(response.status === 415 && (await response.json()).why === "media_type", "only JSON media is accepted");
+const beforeShape = watchCalls;
+response = await worker.fetch(post("{"), env, {});
+t.ok(response.status === 400 && (await response.json()).why === "shape" && watchCalls === beforeShape, "invalid JSON is refused before Watch");
+response = await worker.fetch(post({ ...input, extra: "must-not-be-reflected" }), env, {});
+const shapeText = await response.text();
+t.ok(response.status === 400 && !shapeText.includes("must-not-be-reflected") && watchCalls === beforeShape, "invalid fields are neither forwarded nor reflected");
+
+forgetIdentityBucket();
+response = await worker.fetch(post(input), env, {});
+const publicBody = await response.json();
+t.ok(response.status === 200 && publicBody.schema === IDENTITY_API_SCHEMA && JSON.stringify(publicBody.result) === JSON.stringify(await check(input, index)), "the public route returns the same checked result");
+t.ok(response.headers.get("cache-control") === "no-store" && response.headers.get("access-control-allow-origin") === "*", "success is not cached and is available to integrations");
+
+forgetIdentityBucket();
+response = await worker.fetch(post(input), { IDENTITY_PER_SECOND: "4" }, {});
+t.ok(response.status === 503 && (await response.json()).why === "corpus_unavailable", "a missing Watch binding fails closed");
+
+forgetIdentityBucket();
+const tight = { ...env, IDENTITY_PER_SECOND: "1" };
+const first = await worker.fetch(post(input), tight, {});
+const limited = await worker.fetch(post(input), tight, {});
+t.ok(first.status === 200 && limited.status === 429 && (await limited.json()).why === "rate_limited", "the route has its own per-isolate request bucket");
+
+forgetIdentityBucket();
+const beforeOversize = watchCalls;
+response = await worker.fetch(new Request("https://chain.lintcha.com/api/identity", {
+  method: "POST",
+  headers: { "content-type": "application/json", "content-length": String(IDENTITY_BODY_LIMIT + 1) },
+  body: "{}"
+}), env, {});
+t.ok(response.status === 400 && (await response.json()).why === "shape" && watchCalls === beforeOversize, "a declared oversized body is refused before Watch");
+
+t.done();

--- a/bot/wrangler.toml
+++ b/bot/wrangler.toml
@@ -177,6 +177,9 @@ INDEX_TTL_MS = "600000"
 # courtesy and not a guarantee: many isolates run, and a real global limit would need a write per request.
 TAIL_CACHE_MS = "5000"
 TAIL_PER_SECOND = "4"
+# The opt-in identity POST has its own per-isolate courtesy bucket. It is public for integrations, but the
+# browser comparison never calls it and continues to keep pasted fields local.
+IDENTITY_PER_SECOND = "4"
 # The holder POST has a separate per-isolate courtesy bucket. Origin and media-type checks run before this bucket,
 # and the bucket runs before a request can touch the singleton Watch object. Neither a browser Origin header nor
 # an isolate-local bucket is global admission control; production requires a separately verified dashboard rule.


### PR DESCRIPTION
Adds the opt-in POST /api/identity integration surface over the existing site engine and manifest-bound public index. The browser remains local-only; API requests are bounded, rate-limited, no-store, not persisted, and never echo submitted declarations. Includes focused offline route/DO tests and public documentation.